### PR TITLE
wrap localstorage.set in try

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -53,8 +53,11 @@ export default class Cart extends Component {
       return this.props.client.fetchCart(this.storage.getItem('lastCartId'));
     } else {
       return this.props.client.createCart().then((cart) => {
-        this.storage.setItem('lastCartId', cart.id);
-        return cart;
+        try {
+          this.storage.setItem('lastCartId', cart.id);
+        } finally {
+          return cart;
+        }
       });
     }
   }


### PR DESCRIPTION
everyone's favourite safari bug: calling localstoarge.setItem in private mode throws. 

is it cool to put the return in the `finally` block or should i have an empty `catch` and the put the return after? 

@minasmart @lemonmade @richgilbank 
