### PR TITLE
allow specific variant id

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -6,7 +6,7 @@ import Checkout from './checkout';
 export default class Product extends Component {
   constructor(config, props) {
     super(config, props);
-    this.fixedVariantId = config.variantId;
+    this.defaultVariantId = config.variantId;
     this.cachedImage = null;
     this.childTemplate = new Template(this.config.option.templates, this.config.option.contents, 'options');
     this.cart = null;
@@ -131,7 +131,7 @@ export default class Product extends Component {
 
   setupModel(data) {
     return super.setupModel(data).then((model) => {
-      return this.setFixedVariant(model);
+      return this.setDefaultVariant(model);
     });
   }
 
@@ -226,12 +226,12 @@ export default class Product extends Component {
     }
   }
 
-  setFixedVariant(model) {
-    if (!this.fixedVariantId) {
+  setDefaultVariant(model) {
+    if (!this.defaultVariantId) {
       return model;
     }
 
-    const selectedVariant = model.variants.filter((variant) => variant.id === this.fixedVariantId)[0];
+    const selectedVariant = model.variants.filter((variant) => variant.id === this.defaultVariantId)[0];
     if (selectedVariant) {
       model.options.forEach((option) => {
         option.selected = selectedVariant.optionValues.filter((optionValue) => optionValue.name === option.name)[0].value;

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -273,10 +273,10 @@ describe('Product class', () => {
     });
   });
 
-  describe('setFixedVariant', () => {
-    it('sets selectedVariant to product.fixedVariantId', () => {
-      product.fixedVariantId = 12347;
-      const model = product.setFixedVariant(testProduct);
+  describe('setDefaultVariant', () => {
+    it('sets selectedVariant to product.defalutVariantId', () => {
+      product.defaultVariantId = 12347;
+      const model = product.setDefaultVariant(testProduct);
       assert.equal(model.options[0].selected, 'shark');
       assert.equal(model.options[1].selected, 'large');
     });


### PR DESCRIPTION
allows user to specify `variantId` in config, which sets the initial selected variant to that matching the provided ID. 

@Shopify/buy-button 
