### PR TITLE
Actually evaluate the combined exit statuses

### DIFF
--- a/test-ci
+++ b/test-ci
@@ -18,4 +18,4 @@ mv $lint_output_file $CIRCLE_TEST_REPORTS/xunit/
 unset test_output_file
 unset lint_output_file
 
-exit $test_status || $lint_status
+exit ((test_status + lint_status))


### PR DESCRIPTION
Shell is horrible and I'm not too smart. This does the thing right, so
that if one set of tests pass, the whole thing doesn't pass.
