### PR TITLE
morph callback for images

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -93,7 +93,16 @@ export default class Component {
   }
 
   get morphCallbacks() {
-    return {};
+    return {
+      onBeforeElUpdated(fromEl, toEl) {
+        if (fromEl.tagName === 'IMG') {
+          if (fromEl.src === toEl.getAttribute('data-src')) {
+            return false;
+          }
+        }
+        return true;
+      },
+    };
   }
 
   get iframeClass() {


### PR DESCRIPTION
since we're doing the custom image loading so that we can have image load events, it's generating diffs in morphdom since the src isn't coming from the template. This just checks to see if we're switching between two identical images and cancels the morph in those cases. 

@richgilbank @tanema @harismahmood89 
