### PR TITLE
allow sorting in collections

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -44,15 +44,16 @@ export default class ProductSet extends Component {
   }
 
   get fetchQuery() {
+
+    /* eslint-disable camelcase */
     return {
-      limit: 30,
+      limit: this.options.limit,
       page: 1,
+      sort_by: this.options.sortBy,
     }
   }
 
   sdkFetch(options = {}) {
-
-    /* eslint-disable camelcase */
     options = Object.assign({}, this.fetchQuery, options);
     let method;
     if (this.id) {

--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -120,6 +120,8 @@ const defaults = {
   },
   productSet: {
     iframe: true,
+    sortBy: 'title-ascending',
+    limit: 30,
     manifest: ['product', 'option', 'productSet'],
     contents: {
       title: false,

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -76,7 +76,7 @@ describe('ProductSet class', () => {
 
       it('calls fetchQueryProducts with collection id', () => {
         collection.sdkFetch();
-        assert.calledWith(collection.client.fetchQueryProducts, {collection_id: 1234, page: 1, limit: 30});
+        assert.calledWith(collection.client.fetchQueryProducts, {collection_id: 1234, page: 1, limit: 30, sort_by: 'title-ascending'});
       });
     });
 
@@ -99,7 +99,7 @@ describe('ProductSet class', () => {
       it('calls fetchQueryProducts with collection id', (done) => {
         collection.sdkFetch().then(() => {
           assert.calledWith(collection.client.fetchQueryCollections, {handle: 'hats'});
-          assert.calledWith(collection.client.fetchQueryProducts, {collection_id: 2345, page: 1, limit: 30});
+          assert.calledWith(collection.client.fetchQueryProducts, {collection_id: 2345, page: 1, limit: 30, sort_by: 'title-ascending'});
           done();
         }).catch((e) => {
           done(e);
@@ -124,7 +124,7 @@ describe('ProductSet class', () => {
 
       it('calls fetchQueryProducts with collection id', () => {
         collection.sdkFetch();
-        assert.calledWith(collection.client.fetchQueryProducts, {product_ids: [1234, 2345], page: 1, limit: 30});
+        assert.calledWith(collection.client.fetchQueryProducts, {product_ids: [1234, 2345], page: 1, limit: 30, sort_by: 'title-ascending'});
       });
     });
   });


### PR DESCRIPTION
passing through `options.productSet.sortBy` will override the default sort, which is alphabetical (same as current buy button as far as i can tell)

@richgilbank @minasmart @tanema 
