### PR TITLE
catch fetchqueryproduct empty responses

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -226,13 +226,16 @@ export default class Product extends Component {
     } else if (this.handle) {
       return this.props.client.fetchQueryProducts({handle: this.handle}).then((products) => products[0]);
     }
-    return Promise.resolve();
+    return Promise.reject();
   }
 
   fetchData() {
     return this.sdkFetch().then((model) => {
-      model.selectedQuantity = 0;
-      return model;
+      if (model) {
+        model.selectedQuantity = 0;
+        return model;
+      }
+      throw new Error('Not Found');
     });
   }
 

--- a/src/utils/log-not-found.js
+++ b/src/utils/log-not-found.js
@@ -13,7 +13,7 @@ export default function logNotFound(component) {
       errInfo = `for id ${component.id}.`;
     }
   } else if (component.handle) {
-    errInfo = `for handle "${component.handle}.`;
+    errInfo = `for handle "${component.handle}".`;
   }
   const message = `Not Found: ${component.typeKey} not found ${errInfo}`;
   logger.warn(message);


### PR DESCRIPTION
cleaning up handling of empty responses, since fetchQueryProduct always returns a successful response, just may be an empty array. 

@tanema @minasmart
