### PR TITLE
load appropriate image sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "testem-ci": "testem ci -R xunit > \"${test_output_file}\"",
     "selenium-ci": "NODE_PATH=./node_modules node script/selenium-test.js",
     "test:dev": "npm run watch:test | testem",
-    "test:selenium": "npm run build && NODE_PATH=./node_modules node script/selenium-test.js",
+    "test:selenium": "NODE_PATH=./node_modules node script/selenium-test.js",
     "postinstall": "npm run build"
   },
   "author": "Shopify Inc.",

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -71,10 +71,17 @@ export default class Product extends Component {
 
   get currentImage() {
     if (!this.cachedImage) {
-      this.cachedImage = this.model.selectedVariantImage;
+      this.cachedImage = this.image;
     }
 
     return this.cachedImage;
+  }
+
+  get image() {
+    if (!this.model.selectedVariant.imageVariants) {
+      return null;
+    }
+    return this.model.selectedVariant.imageVariants.find((imageVariant) => imageVariant.name === this.imageSize);
   }
 
   get viewData() {
@@ -214,6 +221,7 @@ export default class Product extends Component {
     }
 
     return Object.assign({}, this.config.modalProduct, {
+      layout: 'horizontal',
       styles: modalProductStyles,
     });
   }
@@ -234,6 +242,10 @@ export default class Product extends Component {
 
   get onlineStoreURL() {
     return `https://${this.props.client.config.domain}/products/${this.id}${this.onlineStoreQueryString}`;
+  }
+
+  get imageSize() {
+    return this.options.imageSize || this.options.layout === 'vertical' ? 'medium' : 'large';
   }
 
   init(data) {

--- a/src/styles/embeds/sass/components/_modal.scss
+++ b/src/styles/embeds/sass/components/_modal.scss
@@ -127,10 +127,8 @@ $modal-footer-height: 90px;
   }
 
   .product-img-wrapper {
-    width: 60%;
-    float: left;
     height: 100%;
-    padding-right: $gutter * 3;
+    padding-right: $gutter * 2;
     max-height: $modal-height;
   }
 
@@ -150,15 +148,5 @@ $modal-footer-height: 90px;
     &:hover {
       color: $color-white;
     }
-  }
-
-  .product__title,
-  .product__variant-title,
-  .product__price,
-  .product__variant-selectors,
-  .quantity-container,
-  .btn,
-  .product-description {
-    overflow: hidden;
   }
 }

--- a/src/styles/embeds/sass/components/_product.scss
+++ b/src/styles/embeds/sass/components/_product.scss
@@ -19,7 +19,7 @@
   font-size: 18px;
   line-height: 1.2;
   color: $color-black;
-  margin-bottom: 0;
+  margin-bottom: $gutter;
   font-weight: 700;
 }
 
@@ -27,16 +27,16 @@
   font-size: 18px;
   color: #666;
   font-weight: 400;
-  margin-top: $gutter;
   text-align: center;
+  margin-bottom: $gutter;
 }
 
 .product__price {
-  margin-top: $gutter;
+  margin-bottom: $gutter;
 }
 
 .product-description {
-  margin-top: $gutter;
+  margin-bottom: $gutter;
   line-height: 1.65;
   color: $color-black;
 
@@ -71,14 +71,14 @@
 }
 
 .product__variant-selectors {
-  margin-top: $gutter;
+  margin-bottom: $gutter;
   text-align: left;
   font-size: 14px;
 }
 
 .quantity-container {
   display: inline-block;
-  margin-top: $gutter + 5;
+  margin-bottom: $gutter + 5;
 }
 
 .quantity {

--- a/test/fixtures/product-fixture.js
+++ b/test/fixtures/product-fixture.js
@@ -15,7 +15,24 @@ const testProduct = {
         name: 'Size',
         value: 'small'
       }
-    ]
+    ],
+    imageVariants: [
+      {
+        name: 'small',
+        dimension: '100x100',
+        src: 'https://cdn.shopify.com/image-two_small.jpg'
+      },
+      {
+        name: 'medium',
+        dimension: '240x240',
+        src: 'https://cdn.shopify.com/image-two_medium.jpg'
+      },
+      {
+        name: 'large',
+        dimension: '480x480',
+        src: 'https://cdn.shopify.com/image-two_large.jpg'
+      },
+    ],
   },
   selectedVariantImage: {
     img: 'http://test.com/test.jpg'
@@ -46,6 +63,23 @@ const testProduct = {
       productId: 123,
       title: 'sloth / small',
       available: true,
+      imageVariants: [
+        {
+          name: 'small',
+          dimension: '100x100',
+          src: 'https://cdn.shopify.com/image-two_small.jpg'
+        },
+        {
+          name: 'medium',
+          dimension: '240x240',
+          src: 'https://cdn.shopify.com/image-two_medium.jpg'
+        },
+        {
+          name: 'large',
+          dimension: '480x480',
+          src: 'https://cdn.shopify.com/image-two_large.jpg'
+        },
+      ],
       optionValues: [
         {
           name: 'Print',
@@ -62,6 +96,23 @@ const testProduct = {
       productId: 123,
       title: 'shark / small',
       available: true,
+      imageVariants: [
+        {
+          name: 'small',
+          dimension: '100x100',
+          src: 'https://cdn.shopify.com/image-two_small.jpg'
+        },
+        {
+          name: 'medium',
+          dimension: '240x240',
+          src: 'https://cdn.shopify.com/image-two_medium.jpg'
+        },
+        {
+          name: 'large',
+          dimension: '480x480',
+          src: 'https://cdn.shopify.com/image-two_large.jpg'
+        },
+      ],
       optionValues: [
         {
           name: 'Print',
@@ -78,6 +129,23 @@ const testProduct = {
       productId: 123,
       title: 'shark / large',
       available: true,
+      imageVariants: [
+        {
+          name: 'small',
+          dimension: '100x100',
+          src: 'https://cdn.shopify.com/image-two_small.jpg'
+        },
+        {
+          name: 'medium',
+          dimension: '240x240',
+          src: 'https://cdn.shopify.com/image-two_medium.jpg'
+        },
+        {
+          name: 'large',
+          dimension: '480x480',
+          src: 'https://cdn.shopify.com/image-two_large.jpg'
+        },
+      ],
       optionValues: [
         {
           name: 'Print',

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -242,7 +242,7 @@ describe('Product class', () => {
     describe('if variant exists', () => {
       it('returns selected image', (done) => {
         product.init(testProductCopy).then(() => {
-          assert.equal(product.currentImage.img, 'http://test.com/test.jpg');
+          assert.equal(product.currentImage.src, 'https://cdn.shopify.com/image-two_medium.jpg');
           done();
         }).catch((e) => {
           done(e);
@@ -255,7 +255,7 @@ describe('Product class', () => {
         product.init(testProductCopy).then(() => {
           product.model.selectedVariant = null;
           product.model.selectedVariantImage = null;
-          assert.equal(product.currentImage.img, 'http://test.com/test.jpg');
+          assert.equal(product.currentImage.src, 'https://cdn.shopify.com/image-two_medium.jpg');
           done();
         }).catch((e) => {
           done(e);
@@ -315,7 +315,7 @@ describe('Product class', () => {
         const viewData = product.viewData;
         assert.equal(viewData.buttonText, 'SHOP NOW');
         assert.ok(viewData.optionsHtml);
-        assert.equal(viewData.currentImage.img, 'http://test.com/test.jpg');
+        assert.equal(viewData.currentImage.src, 'https://cdn.shopify.com/image-two_medium.jpg');
         assert.ok(viewData.hasVariants);
         done();
       }).catch((e) => {
@@ -459,10 +459,18 @@ describe('Product class', () => {
     });
   });
   describe('wrapTemplate', () => {
+    beforeEach((done) => {
+      product.init(testProductCopy).then(() => {
+        done();
+      }).catch((e) => {
+        done(e);
+      });
+    });
+
     describe('when button exists', () => {
       it('calls super', () => {
         const string = product.wrapTemplate('test');
-        assert.equal(string, '<div class="no-image layout-vertical product">test</div>');
+        assert.equal(string, '<div class="has-image layout-vertical product">test</div>');
       });
     });
 
@@ -470,7 +478,7 @@ describe('Product class', () => {
       it('wraps html in a button', () => {
         product.config.product.contents.button = false;
         const string = product.wrapTemplate('test');
-        assert.equal(string, '<div class="no-image layout-vertical product"><button class="btn--parent">test</button></div>');
+        assert.equal(string, '<div class="has-image layout-vertical product"><button class="btn--parent">test</button></div>');
       });
     });
   });
@@ -531,6 +539,7 @@ describe('Product class', () => {
       });
 
       assert.deepEqual(product.modalProductConfig, Object.assign({}, product.config.modalProduct, {
+        layout: 'horizontal',
         styles: expectedStyles,
       }));
     });
@@ -568,6 +577,21 @@ describe('Product class', () => {
           assert.equal(product.onlineStoreURL, `https://test.myshopify.com/products/123${expectedQs}`);
         });
       });
+    });
+  });
+
+  describe('get image', () => {
+    beforeEach((done) => {
+      product.config.product.layout = 'horizontal';
+      product.init(testProductCopy).then(() => {
+        done();
+      }).catch((e) => {
+        done(e);
+      });
+    });
+
+    it('returns the correctly sized image', () => {
+      assert.equal(product.image.name, 'large');
     });
   });
 });


### PR DESCRIPTION
currently the default image size is gigantic, which really sucks in big collections. Setting the default to 'medium' (240px) for vertical layout, 480 for horizontal. Can be overridden. 

In the process, I realized that the modal wasnt' using the horizontal layout, which it ought to be. Also normalized margins for avoiding rage. 

@harismahmood89 @tanema @richgilbank 
