### PR TITLE
transparent backgrounds for line item images

### DIFF
--- a/src/styles/embeds/sass/components/_cart.scss
+++ b/src/styles/embeds/sass/components/_cart.scss
@@ -86,7 +86,7 @@ $cart-item-height: 65px;
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center center;
-  background-color: #e5e5e5;
+  background-color: transparent;
   position: absolute;
   left: 0;
   top: 0;


### PR DESCRIPTION
super tiny fix for https://github.com/Shopify/buy-button/issues/1701

@tanema @tessalt 
