### PR TITLE
Styletext override

### DIFF
--- a/src/shopify-buy-ui.js
+++ b/src/shopify-buy-ui.js
@@ -5,9 +5,9 @@ import productTemplates from './templates/product';
 ShopifyBuy.UI = {
   ui: null,
 
-  init(client, integrations = {}) {
+  init(client, integrations = {}, styleOverrides) {
     if (!this.ui) {
-      this.ui = new UI(client, integrations);
+      this.ui = new UI(client, integrations, styleOverrides);
     }
     return this.ui;
   },

--- a/src/ui.js
+++ b/src/ui.js
@@ -33,6 +33,7 @@ export default class UI {
     };
     this.errorReporter = integrations.errorReporter;
     this.tracker = new Tracker(integrations.tracker);
+    this.styleOverrides = styleOverrides;
     this.tracker.trackPageview();
     this._appendStyleTag();
     this._bindResize();
@@ -125,9 +126,9 @@ export default class UI {
 
   get styleText() {
     if (browserFeatures.transition && browserFeatures.transform && browserFeatures.animation) {
-      return this.hostStyles;
+      return hostStyles + this.styleOverrides;
     }
-    return this.hostStyles + conditionalStyles;
+    return hostStyles + conditionalStyles + this.styleOverrides;
   }
 
   _queryEntryNode() {


### PR DESCRIPTION
allows additional styles to be added to the host css string. Useful for anything that may extend buybutton.js (current case being storefront)

@harismahmood89 @tanema 
