### PR TITLE
don't show default variant title

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -63,6 +63,7 @@ export default class Cart extends Component {
       const data = lineItem;
       data.classes = this.classes;
       data.lineItemImage = data.image || {src: NO_IMG_URL};
+      data.variantTitle = data.variant_title === 'Default Title' ? '' : data.variant_title;
       return acc + this.childTemplate.render({data}, (output) => `<div id="${lineItem.id}" class=${this.classes.lineItem.lineItem}>${output}</div>`);
     }, '');
   }

--- a/src/templates/line-item.js
+++ b/src/templates/line-item.js
@@ -1,6 +1,6 @@
 const lineItemTemplates = {
   image: '<div class="{{data.classes.lineItem.image}}" style="background-image: url({{data.lineItemImage.src}})"></div>',
-  variantTitle: '<div class="{{data.classes.lineItem.variantTitle}}">{{data.variant_title}}</div>',
+  variantTitle: '<div class="{{data.classes.lineItem.variantTitle}}">{{data.variantTitle}}</div>',
 
   title: '<span class="{{data.classes.lineItem.itemTitle}}">{{data.title}}</span>',
   price: '<span class="{{data.classes.lineItem.price}}">${{data.line_price}}</span>',


### PR DESCRIPTION
ideally i would be checking `variants.length` but that's not available on `lineItem` so only way to figure this out is to compare strings.

fixes https://github.com/Shopify/buy-button-js/issues/195

@tanema @michelleyschen @harisaurus 
cc @richgilbank 
