### PR TITLE
modal style fixes

### DIFF
--- a/src/styles/embeds/sass/components/_modal.scss
+++ b/src/styles/embeds/sass/components/_modal.scss
@@ -4,9 +4,9 @@ $modal-footer-height: 90px;
 .btn--close {
   right: 0px;
   font-size: 45px;
-  padding-right: 3px;
   font-weight: 100;
   z-index: $max-z-index;
+  padding: 0 10px;
 }
 
 .modal {
@@ -56,6 +56,7 @@ $modal-footer-height: 90px;
     overflow: hidden;
     position: fixed;
     height: 100vh;
+    transition: all 0s;
   }
 
   .modal {
@@ -82,7 +83,7 @@ $modal-footer-height: 90px;
   .btn--close {
     position: fixed;
     top: 0;
-    right: 10px;
+    right: 0;
   }
 }
 

--- a/src/styles/embeds/sass/components/_product.scss
+++ b/src/styles/embeds/sass/components/_product.scss
@@ -7,7 +7,7 @@
 
 .product__variant-img {
   margin: 0 auto $gutter auto;
-  transition: all 0.3s ease;
+  transition: opacity 0.3s ease;
   opacity: 1;
 
   &.is-transitioning {


### PR DESCRIPTION
Couple things @richgilbank pointed out yesterday
- the `transition: all 0s` is so that the `transitionend` event will fire when the modal is closed, which allows me to remove a class from the iframe. This was causing the brief delay that rich noticed. Decided to go this route rather than having browser size awareness in the JS
- makes close button hit area larger
- fixes weird transition on modal image

@harisaurus @michelleyschen 
