### PR TITLE
resize until loaded on updateconfig

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -590,8 +590,7 @@ export default class Product extends Component {
       this.iframe.removeClass(this.classes.product.vertical);
       this.iframe.removeClass(this.classes.product.horizontal);
       this.iframe.addClass(this.classes.product[layout]);
-      this._resizeX();
-      this._resizeY();
+      this.resizeUntilLoaded();
     }
     super.updateConfig(config);
     if (this.cart) {


### PR DESCRIPTION
@harisaurus I _think_ this _might_ fix our resizing problem. I mean, it should. The reason sizes were being set on the iframe is that I was manually calling `resizeX` which skips the check for `shouldResizeX`. 

cc @tanema @michelleyschen 
