### PR TITLE
cut off really really long cart headers

### DIFF
--- a/src/styles/embeds/sass/components/_cart.scss
+++ b/src/styles/embeds/sass/components/_cart.scss
@@ -114,6 +114,8 @@ $cart-item-height: 65px;
   font-size: 11px;
   font-weight: bold;
   max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .shopify-buy__cart-bottom {


### PR DESCRIPTION
In the event that someone sets the cart title to something really, really long, with no spaces, it now clips it nicely. 

Tested with what is apparently the longest word in the german language, _Rindfleischetikettierungsueberwachungsaufgabenuebertragungsgesetz_ , meaning "law delegating beef label monitoring"

![image](https://cloud.githubusercontent.com/assets/1789029/19480537/b853b9b8-9518-11e6-8855-2f983cc85c81.png)

@harisaurus @michelleyschen 
