### PR TITLE
collapse margins between components

### DIFF
--- a/src/styles/embeds/sass/components/_product.scss
+++ b/src/styles/embeds/sass/components/_product.scss
@@ -167,6 +167,15 @@
     margin: ($gutter + 5) auto 0;
   }
 
+  .shopify-buy__btn-and-quantity {
+    margin: ($gutter + 5) auto 0;
+
+    .shopify-buy__btn,
+    .shopify-buy__quantity-container {
+      margin: 0 auto;
+    }
+  }
+
   .shopify-buy__product__variant-img {
     max-width: 100%;
   }


### PR DESCRIPTION
fixes https://github.com/Shopify/buy-button/issues/1904

margins weren't collapsing in the button-with-quantity because the margins were inside a wrapper. This moves the margins up to the wrapper so they do now collapse as they do with just the button. 

@harisaurus @michelleyschen cc @andreygargul 
