### PR TITLE
fix firefox & safari

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -293,7 +293,7 @@ export default class Component {
    * @return {String} value in pixels.
    */
   get outerHeight() {
-    return this.document.defaultView.getComputedStyle(this.wrapper, '').getPropertyValue('height');
+    return window.getComputedStyle(this.wrapper, '').getPropertyValue('height');
   }
 
   /**

--- a/src/styles/embeds/sass/components/_collection.scss
+++ b/src/styles/embeds/sass/components/_collection.scss
@@ -19,6 +19,7 @@
   flex: 0 0 auto;
   display: inline-block;
   max-width: 250px;
+  width: auto;
 }
 
 .shopify-buy__btn.shopify-buy__collection-pagination-button  {


### PR DESCRIPTION
firefox wasn't happy with `document.defaultView` and according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) this should have consistently the same results. 

Safari didn't like the `width: 100%` that was getting applied to products in the collection view. 

@harisaurus @michelleyschen 
