### PR TITLE
make classname utils work in strict mode

### DIFF
--- a/src/iframe.js
+++ b/src/iframe.js
@@ -1,6 +1,7 @@
 import hogan from 'hogan.js';
 import stylesTemplate from './templates/styles';
 import conditionalStyles from './styles/embeds/conditional';
+import {addClassToElement, removeClassFromElement} from './utils/element-class';
 
 const iframeStyles = {
   width: '100%',
@@ -150,18 +151,15 @@ export default class iframe {
   }
 
   addClass(className) {
-    if (this.parent.className.indexOf(className) < 0) {
-      this.parent.className += ` ${className}`;
-    }
+    addClassToElement(className, this.parent);
+  }
+
+  removeClass(className) {
+    removeClassFromElement(className, this.parent);
   }
 
   setName(name) {
     this.el.setAttribute('name', name);
-  }
-
-  removeClass(className) {
-    const newClass = this.parent.className.replace(className, '');
-    this.parent.className = newClass;
   }
 
   get document() {

--- a/src/utils/element-class.js
+++ b/src/utils/element-class.js
@@ -1,4 +1,7 @@
 export function addClassToElement(className, element) {
+  if (!className) {
+    return;
+  }
   if (element.classList) {
     element.classList.add(className);
   } else {
@@ -7,6 +10,9 @@ export function addClassToElement(className, element) {
 }
 
 export function removeClassFromElement(className, element) {
+  if (!className) {
+    return;
+  }
   if (element.classList) {
     element.classList.remove(className);
   } else {

--- a/test/unit/modal.js
+++ b/test/unit/modal.js
@@ -81,26 +81,15 @@ describe('Modal class', () => {
     it('sets isVisible to false', () => {
       modal.iframe = {
         removeClass: sinon.spy(),
-        parent: {
-          addEventListener: sinon.spy(),
-        },
+        parent: document.createElement('div'),
         document: {
-          body: {
-            classList: '',
-            className: 'is-active',
-          }
+          body: document.createElement('body'),
         }
       }
-      modal.wrapper = {
-        classList: {
-          remove: sinon.spy()
-        }
-      }
+      modal.wrapper = document.createElement('div');
       modal.close();
       assert.notOk(modal.isVisible);
       assert.calledWith(modal.iframe.removeClass, 'is-active');
-      assert.calledWith(modal.wrapper.classList.remove, 'is-active');
-      assert.calledWith(modal.iframe.parent.addEventListener, 'transitionend', sinon.match.func);
       assert(modal.iframe.document.body.className.length < 1);
     });
   });


### PR DESCRIPTION
turns out `className` is supposed to be read-only. 

@harisaurus @michelleyschen @tanema 
