### PR TITLE
get rid of un-use css left over from button style

### DIFF
--- a/src/styles/embeds/sass/components/_buttons.scss
+++ b/src/styles/embeds/sass/components/_buttons.scss
@@ -25,11 +25,8 @@
 .shopify-buy__btn--parent {
   background-color: transparent;
   border: 0;
-  line-height: 1;
   padding: 0;
   cursor: pointer;
-  -moz-appearance: none;
-  -webkit-appearance: none;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Fix https://github.com/Shopify/buy-button/issues/1915

@tessalt @harisaurus 
