### PR TITLE
close cart on collection bg click

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -67,6 +67,7 @@ export default class ProductSet extends Component {
    */
   get DOMEvents() {
     return Object.assign({}, {
+      click: this.props.closeCart.bind(this),
       [`click ${this.selectors.productSet.paginationButton}`]: this.nextPage.bind(this),
     }, this.options.DOMEvents);
   }


### PR DESCRIPTION
if the last row of your collection isn't full and therefore has empty space, clicking on this empty space should close the cart. @harisaurus @michelleyschen 
