### PR TITLE
use svgs for quantity controls, and update heights and font sizing

### DIFF
--- a/src/styles/embeds/sass/components/_quantity.scss
+++ b/src/styles/embeds/sass/components/_quantity.scss
@@ -2,7 +2,7 @@
 .shopify-buy__quantity-increment {
   color: $color-title;
   display: block;
-  height: 26px;
+  height: 30px;
   float: left;
   line-height: 16px;
   font-family: monospace;
@@ -16,6 +16,18 @@
   text-align: center;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   border: 1px solid $color-quantity-border;
+  position: relative;
+
+  svg {
+    width: 14px;
+    height: 14px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-top: -6px;
+    margin-left: -7px;
+    fill: currentColor;
+  }
 }
 
 .shopify-buy__quantity-decrement {
@@ -29,8 +41,8 @@
 .shopify-buy__quantity {
   color: black;
   width: 45px;
-  height: 26px;
-  font-size: 12px;
+  height: 30px;
+  font-size: 16px;
   border: none;
   text-align: center;
   -moz-appearance: textfield;

--- a/src/templates/line-item.js
+++ b/src/templates/line-item.js
@@ -5,9 +5,9 @@ const lineItemTemplates = {
   title: '<span class="{{data.classes.lineItem.itemTitle}}">{{data.title}}</span>',
   price: '<span class="{{data.classes.lineItem.price}}">${{data.line_price}}</span>',
   quantity: `<div class="{{data.classes.lineItem.quantity}}">
-              <button class="{{data.classes.lineItem.quantityButton}} {{data.classes.lineItem.quantityDecrement}}" type="button" data-line-item-id="{{data.id}}"><span>-</span><span class="visuallyhidden">Decrement</span></button>
+              <button class="{{data.classes.lineItem.quantityButton}} {{data.classes.lineItem.quantityDecrement}}" type="button" data-line-item-id="{{data.id}}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M4 7h8v2H4z"/></svg><span class="visuallyhidden">Decrement</span></button>
               <input class="{{data.classes.lineItem.quantityInput}}" type="number" min="0" aria-label="Quantity" data-line-item-id="{{data.id}}" value="{{data.quantity}}">
-              <button class="{{data.classes.lineItem.quantityButton}} {{data.classes.lineItem.quantityIncrement}}" type="button" data-line-item-id="{{data.id}}"><span>+</span><span class="visuallyhidden">Increment</span></button>
+              <button class="{{data.classes.lineItem.quantityButton}} {{data.classes.lineItem.quantityIncrement}}" type="button" data-line-item-id="{{data.id}}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M12 7H9V4H7v3H4v2h3v3h2V9h3z"/></svg><span class="visuallyhidden">Increment</span></button>
             </div>`,
 };
 


### PR DESCRIPTION
- update quantity size to `30px` in height
- update font-size to `16px` to prevent iOS zooming
- switch out `+/-` text with svg icons and add required styling

@tessalt @tanema @michelleyschen 

cc @richgilbank @andreygargul 

Chrome:
![image](https://cloud.githubusercontent.com/assets/6800875/19570411/e34878b0-96c7-11e6-8bce-77389c27e6ed.png)
