### PR TITLE
correct online store url for product handles

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -438,7 +438,8 @@ export default class Product extends Component {
    * @return {String}
    */
   get onlineStoreURL() {
-    return `https://${this.props.client.config.domain}/products/${this.id}${this.onlineStoreQueryString}`;
+    const identifier = this.handle ? this.handle : this.id;
+    return `https://${this.props.client.config.domain}/products/${identifier}${this.onlineStoreQueryString}`;
   }
 
   /**

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -570,8 +570,13 @@ describe('Product class', () => {
       });
 
       describe('get onlineStoreURL', () => {
-        it('returns URL for a product on online store', () => {
+        it('returns URL for a product ID on online store', () => {
           assert.equal(product.onlineStoreURL, `https://test.myshopify.com/products/123${expectedQs}`);
+        });
+
+        it('returns URL for a product handle on online store', () => {
+          product.handle = 'fancy-product';
+          assert.equal(product.onlineStoreURL, `https://test.myshopify.com/products/fancy-product${expectedQs}`);
         });
       });
     });


### PR DESCRIPTION
legacy buy buttons use product handles, not IDs. 
