### PR TITLE
pass reference to contentWindow to google fonts

### DIFF
--- a/src/iframe.js
+++ b/src/iframe.js
@@ -118,7 +118,7 @@ export default class iframe {
           google: {
             families: this.googleFonts,
           },
-          context: frames[this.name],
+          context: this.el.contentWindow || frames[this.name],
         });
       }
       return true;


### PR DESCRIPTION
@tanema @michelleyschen 

getting frame by name doesn't work if the frame is nested more than one level deep, as in the embed builder. 

The fallback to `frames[this.name]` is probably not necessary?? but im paranoid
