### PR TITLE
computed style backup

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -293,7 +293,11 @@ export default class Component {
    * @return {String} value in pixels.
    */
   get outerHeight() {
-    return window.getComputedStyle(this.wrapper, '').getPropertyValue('height');
+    const style = window.getComputedStyle(this.wrapper, '');
+    if (!style) {
+      return `${this.wrapper.clientHeight}px`;
+    }
+    return style.getPropertyValue('height');
   }
 
   /**


### PR DESCRIPTION
this isn't a great solution because I still haven't narrowed down the very rare occasions in which `getPropertyValue` will throw, but this should keep it from throwing and set a height anyways (albeit an occasionally-less-accurate one).

@tanema @michelleyschen 
