### PR TITLE
expose classname for hidden label

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -171,6 +171,7 @@ const defaults = {
       optionDisabled: 'shopify-buy__option--disabled',
       optionSelected: 'shopify-buy__option--selected',
       selectIcon: 'shopify-buy__select-icon',
+      hiddenLabel: 'visuallyhidden',
     },
   },
   cart: {

--- a/src/templates/option.js
+++ b/src/templates/option.js
@@ -1,6 +1,6 @@
 const optionTemplates = {
   option: `<div class={{data.classes.option.option}}>
-    <label class="{{data.classes.option.label}} {{#data.onlyOption}}visuallyhidden{{/data.onlyOption}}">{{data.name}}</label>
+    <label class="{{data.classes.option.label}} {{#data.onlyOption}}{{data.classes.option.hiddenLabel}}{{/data.onlyOption}}">{{data.name}}</label>
       <div class="{{data.classes.option.wrapper}}">
       <select class="{{data.classes.option.select}}" name="{{data.name}}">
         {{#data.values}}


### PR DESCRIPTION
currently, the label for an option select menu is only shown if there is more than one option. This PR exposes the `visuallyhidden` class name so that this behaviour can be overridden. Can be overridden in two ways: 

removing the class:

```
options: {
  option: {
     classes: {
      hiddenLabel: ''
    }
  }
}
```

or un-doing the styles: 

```
options: {
  option: {
     styles: {
      hiddenLabel: {
        'position': 'static',
        'height': 'auto',
        'overflow': 'visible',
      }
    }
  }
}
```

@tanema @michelleyschen cc @harisaurus 
