### PR TITLE
update the compare at pricing to have 65% opacity

### DIFF
--- a/src/styles/embeds/sass/components/_product.scss
+++ b/src/styles/embeds/sass/components/_product.scss
@@ -109,6 +109,7 @@
   font-size: 12px;
   text-decoration: line-through;
   padding-left: 5px;
+  opacity: 0.65;
 }
 
 .shopify-buy__product__variant-selectors {


### PR DESCRIPTION
Fix https://github.com/Shopify/buy-button/issues/1966
@harisaurus @tessalt 

A update to make the price+ compare at price color to be the same are coming for the builder
