### PR TITLE
prevent UI from being reinitialized

### DIFF
--- a/src/buybutton.js
+++ b/src/buybutton.js
@@ -2,7 +2,9 @@ import ShopifyBuy from 'shopify-buy/dist/shopify-buy.umd.polyfilled';
 import UI from './ui';
 import productTemplates from './templates/product';
 
-ShopifyBuy.UI = {
+window.ShopifyBuy = window.ShopifyBuy || ShopifyBuy;
+
+ShopifyBuy.UI = window.ShopifyBuy.UI || {
   ui: null,
 
   init(client, integrations = {}, styleOverrides) {
@@ -21,5 +23,4 @@ ShopifyBuy.UI = {
   UIConstructor: UI,
 };
 
-window.ShopifyBuy = window.ShopifyBuy || ShopifyBuy;
 export default ShopifyBuy;


### PR DESCRIPTION
@tanema @michelleyschen @harisaurus this prevents ShopifyBuy.UI from being re-initialized (which recreated the namespace leading to multiple carts which we do not want).

