### PR TITLE
force reflow in firefox

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -300,7 +300,7 @@ export default class Component {
     let height = style.getPropertyValue('height');
     if (!height || height === '0px' || height === 'auto') {
       const clientHeight = this.wrapper.clientHeight;
-      height = style.getPropertyValue('height') || `${this.wrapper.clientHeight}px`;
+      height = style.getPropertyValue('height') || `${clientHeight}px`;
     }
     return height;
   }


### PR DESCRIPTION
I am at somewhat of a loss to explain this. My best guess is that firefox does not force a repaint on `getComputedStyle` while webkit does. My janky solution is to check if getCoputedStyle gave me something useful, and if not, force repaint and try again. 

Maybe someday I will understand how browsers work and make this not suck.

@harisaurus @tanema @michelleyschen 