### PR TITLE
apply max width for options container

### DIFF
--- a/src/styles/embeds/sass/components/_product.scss
+++ b/src/styles/embeds/sass/components/_product.scss
@@ -115,6 +115,12 @@
 .shopify-buy__product__variant-selectors {
   text-align: left;
   font-size: 14px;
+
+  .shopify-buy__layout-vertical & {
+    max-width: 280px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .shopify-buy__quantity {


### PR DESCRIPTION
Enforce a `max-width` of `280px` (size of small embeds) for options container to ensure they don't look awkward when on medium/large embed size.

Fix required for https://github.com/Shopify/buy-button/issues/1951

@tessalt @tanema @michelleyschen 

cc/ @andreygargul 

![image](https://cloud.githubusercontent.com/assets/6800875/19870688/fea0edc2-9f87-11e6-8e2e-048f2a62f481.png)
