### PR TITLE
prevent adapter from throwing when collections request is empty

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -129,9 +129,12 @@ export default class ProductSet extends Component {
       method = this.props.client.fetchQueryProducts(Object.assign({}, queryOptions, {[queryKey]: this.id}));
     } else if (this.handle) {
       method = this.props.client.fetchQueryCollections({handle: this.handle}).then((collections) => {
-        const collection = collections[0];
-        this.id = collection.attrs.collection_id;
-        return this.sdkFetch(options);
+        if (collections.length) {
+          const collection = collections[0];
+          this.id = collection.attrs.collection_id;
+          return this.sdkFetch(options);
+        }
+        return Promise.resolve([]);
       });
     }
     return method;

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -48,7 +48,7 @@ describe('ProductSet class', () => {
   });
 
   describe('sdkFetch', () => {
-    describe('when passed a colleciton ID', () => {
+    describe('when passed a collection ID', () => {
       let collection;
 
       beforeEach(() => {
@@ -57,14 +57,15 @@ describe('ProductSet class', () => {
           options: config.options,
         }, {
           client: {
-            fetchQueryProducts: sinon.spy()
+            fetchQueryProducts: sinon.stub().returns(Promise.resolve([]))
           },
           createCart: () => Promise.resolve()
         });
       });
 
       it('calls fetchQueryProducts with collection id', () => {
-        collection.sdkFetch();
+        const result = collection.sdkFetch();
+        assert.ok(result.then);
         assert.calledWith(collection.client.fetchQueryProducts, {collection_id: 1234, page: 1, limit: 30, sort_by: 'collection-default'});
       });
     });
@@ -102,14 +103,15 @@ describe('ProductSet class', () => {
           options: config.options,
         }, {
           client: {
-            fetchQueryProducts: sinon.spy()
+            fetchQueryProducts: sinon.stub().returns(Promise.resolve([]))
           },
           createCart: () => Promise.resolve()
         });
       });
 
       it('calls fetchQueryProducts with collection id', () => {
-        collection.sdkFetch();
+        const result = collection.sdkFetch();
+        assert.ok(result.then);
         assert.calledWith(collection.client.fetchQueryProducts, {product_ids: [1234, 2345], page: 1, limit: 30, sort_by: 'collection-default'});
       });
     });


### PR DESCRIPTION
if a collection doesn't exist or isn't published it throws on `collection.attrs`

@harisaurus @michelleyschen @tanema 