### PR TITLE
prevent calls to getcomputed style before element exists

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -313,7 +313,7 @@ export default class Component {
    * resize iframe if necessary.
    */
   resize() {
-    if (!this.iframe) {
+    if (!this.iframe || !this.wrapper) {
       return;
     }
     if (this.shouldResizeX) {


### PR DESCRIPTION
`resize` would throw occasionally if the browser was resized before the `this.wrapper` existed because it was trying to calculate size of a nonexistent element. 

@harisaurus @tanema @michelleyschen 