### PR TITLE
consume es6 instead of umd

### DIFF
--- a/src/buybutton.js
+++ b/src/buybutton.js
@@ -1,4 +1,4 @@
-import ShopifyBuy from 'shopify-buy/dist/shopify-buy.umd.polyfilled';
+import ShopifyBuy from 'shopify-buy/lib/shopify-polyfilled';
 import UI from './ui';
 import productTemplates from './templates/product';
 


### PR DESCRIPTION
so. 

If require.js is included on the page, then then `import ShopifyBuy` will fail if I'm pointing to the UMD build, because the umd script will be like "hey is `window.define` a thing?" and window will be like "you bet" and then it's like ok I guess i'm _not_ going to `module.exports` so then I get NOTHING. 

the es6 build is about 10kb bigger.

@tanema @michelleyschen

cc @mikkoh @minasmart  