### PR TITLE
prevent modals from disappearing for good after updateconfig

### DIFF
--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -16,7 +16,7 @@ export default class Modal extends Component {
    */
   constructor(config, props) {
     super(config, props);
-    this.node = config.node.appendChild(document.createElement('div')) || document.body.appendChild(document.createElement('div'));
+    this.node = config.node ? config.node.appendChild(document.createElement('div')) : document.body.appendChild(document.createElement('div'));
     this.node.className = 'shopify-buy-modal-wrapper';
     this.product = null;
   }

--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -16,7 +16,7 @@ export default class Modal extends Component {
    */
   constructor(config, props) {
     super(config, props);
-    this.node = config.node || document.body.appendChild(document.createElement('div'));
+    this.node = config.node.appendChild(document.createElement('div')) || document.body.appendChild(document.createElement('div'));
     this.node.className = 'shopify-buy-modal-wrapper';
     this.product = null;
   }


### PR DESCRIPTION
`updateConfig` destroys the DOM node which was a problem if a custom DOM node was being passed in because then it wouldn't exist the next time around. 

@harisaurus @michelleyschen @tanema 
