### PR TITLE
collection product style fixes

### DIFF
--- a/src/styles/embeds/sass/components/_collection.scss
+++ b/src/styles/embeds/sass/components/_collection.scss
@@ -7,10 +7,7 @@
   justify-content: center;
   flex-wrap: wrap;
   margin-left: -$gutter;
-
-  @media (max-width: 600px) {
-    display: block;
-  }
+  text-align: center;
 }
 
 .shopify-buy__product {
@@ -18,6 +15,7 @@
   margin-bottom: $gutter;
   flex: 0 0 auto;
   display: inline-block;
+  vertical-align: top;
   max-width: 250px;
   width: auto;
 }


### PR DESCRIPTION
ensure collection products are centered and vertically aligned with correct fallbacks for flexbox

- collection wrapper currently removed reverted `display: flex` to `block` at smaller breakpoints. this was unnecessary and therefore removed
- when flexbox is unavailable, the inline-blocked elements require `vertical-align:top` to be top aligned, along with `text-align:center` on the wrapper element for them to be horizontally centered

@tanema @tessalt @michelleyschen 

**Before**
![image](https://cloud.githubusercontent.com/assets/6800875/20063675/13ab2d10-a4d6-11e6-8727-8df5d306cded.png)

**After** (Both with flexbox, and with flexbox fallbacks)
![image](https://cloud.githubusercontent.com/assets/6800875/20063692/2b68f748-a4d6-11e6-8642-73f381800abc.png)
