### PR TITLE
Fix product sets

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -85,7 +85,6 @@ export default class ProductSet extends Component {
     return {
       limit: 30,
       page: 1,
-      sort_by: 'collection-default',
     };
 
     /* eslint-enable camelcase */
@@ -125,7 +124,13 @@ export default class ProductSet extends Component {
     const queryOptions = Object.assign({}, this.fetchQuery, options);
     let method;
     if (this.id) {
-      const queryKey = isArray(this.id) ? 'product_ids' : 'collection_id';
+      let queryKey;
+      if (isArray(this.id)) {
+        queryKey = 'product_ids';
+      } else {
+        queryKey = 'collection_id';
+        queryOptions.sort_by = 'collection-default';
+      }
       method = this.props.client.fetchQueryProducts(Object.assign({}, queryOptions, {[queryKey]: this.id}));
     } else if (this.handle) {
       method = this.props.client.fetchQueryCollections({handle: this.handle}).then((collections) => {

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -112,7 +112,7 @@ describe('ProductSet class', () => {
       it('calls fetchQueryProducts with collection id', () => {
         const result = collection.sdkFetch();
         assert.ok(result.then);
-        assert.calledWith(collection.client.fetchQueryProducts, {product_ids: [1234, 2345], page: 1, limit: 30, sort_by: 'collection-default'});
+        assert.calledWith(collection.client.fetchQueryProducts, {product_ids: [1234, 2345], page: 1, limit: 30});
       });
     });
   });


### PR DESCRIPTION
fixes the broken embed on the blog post. `collection_sort` param was being sent for both collections and arrays of product IDs. API does not like it when it gets `collection_sort` but no `collection_id`

@michelleyschen @harisaurus @tanema 