### PR TITLE
make sure the checkout popup would have scroll bar in all browser

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -273,7 +273,7 @@ const defaults = {
     height: 600,
     width: 400,
     toolbar: 0,
-    scrollbars: 0,
+    scrollbars: 1,
     status: 0,
     resizable: 1,
     center: 0,


### PR DESCRIPTION
Fix https://github.com/Shopify/buy-button/issues/2015

@tessalt @harisaurus 