### PR TITLE
export commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "rollup-plugin-babel": "2.6.1",
     "rollup-plugin-commonjs": "3.3.1",
     "rollup-plugin-node-resolve": "1.7.1",
-    "shopify-buy": "0.4.0",
+    "shopify-buy": "0.4.2",
     "uglify-js": "2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "@shopify/buy-button-js",
   "version": "0.1.34",
   "description": "BuyButton.js allows merchants to build Shopify interfaces into any website",
-  "main": "lib/buybutton.umd.js",
-  "jsnext:main": "lib/buybutton.es.js",
+  "main": "lib/buybutton.cjs.js",
   "repository": "git@github.com:Shopify/buy-button-js.git",
   "scripts": {
     "start": "rm -rf tmp && mkdir tmp && npm run src:watch & npm run styles:watch & npm run serve",
@@ -11,7 +10,7 @@
     "test": "npm run lint && npm run testem",
     "serve": "http-server",
     "lint": "eslint --max-warnings=0 $([ -n \"${CI}\" ] && echo -o $CIRCLE_TEST_REPORTS/xunit/lint-output.xml -f junit) src/*",
-    "clean": "rm -rf dist && mkdir dist ",
+    "clean": "rm -rf dist lib && mkdir dist lib",
     "styles": "npm run styles-embeds:build && npm run styles-host:build",
     "prepublish": "npm run build",
     "docs": "jekyll serve -s docs",

--- a/script/build.js
+++ b/script/build.js
@@ -12,7 +12,7 @@ const buildPaths = {
   globals: 'dist/buybutton.js',
   min: 'dist/buybutton.min.js',
   umd: 'lib/buybutton.umd.js',
-  es: 'lib/buybutton.es.js',
+  cjs: 'lib/buybutton.cjs.js',
 }
 
 rollup({
@@ -40,8 +40,8 @@ rollup({
       moduleName: 'ShopifyBuy',
     }),
     bundle.write({
-      dest: buildPaths.es,
-      format: 'es',
+      dest: buildPaths.cjs,
+      format: 'cjs',
       moduleName: 'ShopifyBuy',
     }),
   ]);


### PR DESCRIPTION
turns out UMD is no good for third-party js because it looks for `define` and makes decisions based on that which is bad because sometimes people do crazy things like use requirejs. 

I also got rid of the es6 build because it's untested. 

I also made sure we're rm -rf ing lib because I forgot to before because I'm bad. 

once https://github.com/Shopify/js-buy-sdk/pull/266 merges I can fix the requirejs bug. 

@michelleyschen @tanema cc @mikkoh 