### PR TITLE
add option to open checkout in same pane

### DIFF
--- a/src/components/checkout.js
+++ b/src/components/checkout.js
@@ -13,6 +13,10 @@ export default class Checkout {
   }
 
   open(url) {
-    window.open(url, 'checkout', this.params);
+    if (this.config.cart.popup) {
+      window.open(url, 'checkout', this.params);
+    } else {
+      window.location = url;
+    }
   }
 }

--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -178,6 +178,7 @@ const defaults = {
     iframe: true,
     templates: cartTemplates,
     startOpen: false,
+    popup: true,
     manifest: ['cart', 'lineItem', 'toggle'],
     contents: {
       title: true,


### PR DESCRIPTION
allow users to pass `options.cart.popup = false` to redirect current page to checkout instead of opening a new page. 

Are there consequences to do this or reasons we didn't do this before? I don't remember. 

@tanema @michelleyschen @harisaurus @richgilbank 