### PR TITLE
prevent calling resize on iframe-less components

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -264,7 +264,7 @@ export default class UI {
     window.addEventListener('safeResize', () => {
       this.components.collection.forEach((collection) => collection.resize());
       this.components.productSet.forEach((set) => set.resize());
-      this.components.product.forEach((product) => product._resizeY());
+      this.components.product.forEach((product) => product.resize());
     });
   }
 


### PR DESCRIPTION
directly calling `_resizeY` was obviously a bad idea, since `resize` should always called directly as it contains the logic for whether or not `_resizeX` and `_resizeY` should be called. 

@harisaurus @tanema @michelleyschen 