### PR TITLE
add uploader class

### DIFF
--- a/script/deploy.js
+++ b/script/deploy.js
@@ -2,14 +2,10 @@
 
 const path = require('path');
 const fs = require('fs');
-const mime = require('mime-types');
 const currentVersion = require('../package.json').version;
-const s3Dir = 'buy-button';
 const awsConfig = require('../config.json').aws;
 const awsSDK = require('aws-sdk');
-const distDir = 'dist';
-const filePaths = fs.readdirSync(distDir);
-const defaultContentType = 'application/javascript';
+const Uploader = require('./util/uploader');
 
 const awsS3 = new awsSDK.S3({
   accessKeyId: awsConfig.accessKeyId,
@@ -21,29 +17,12 @@ const awsS3 = new awsSDK.S3({
   }
 });
 
-const uploadFile = function(filePath, s3Key) {
-  awsS3.putObject({
-    Body: fs.readFileSync(distDir + '/' + filePath),
-    Key: s3Key,
-    ContentType: getContentType(distDir + '/' + filePath),
-  }, function(error) {
-    if(error) {
-      return console.error('Error uploading ' + filePath, error);
-    }
-
-    console.info('Uploaded "' + filePath + '" to S3 as "' + s3Key + '"');
-  });
-}
-
-const getContentType = function(filePath) {
-  return mime.lookup(filePath) || defaultContentType;
-}
-
-filePaths.map(function(filePath) {
-  const basename = path.basename(filePath);
-  const latestName = s3Dir + '/latest/' + basename;
-  const versionedName = s3Dir + '/' + currentVersion + '/' + basename;
-
-  uploadFile(filePath, latestName);
-  uploadFile(filePath, versionedName);
+const uploader = new Uploader({
+  s3: awsS3,
+  dir: 'dist',
+  destination: 'buy-button',
+  version: currentVersion,
 });
+
+uploader.deployStaticFiles();
+uploader.npmPublish();

--- a/script/util/uploader.js
+++ b/script/util/uploader.js
@@ -1,0 +1,125 @@
+"use strict";
+
+const path = require('path');
+const request = require('request');
+const fs = require('fs');
+const mime = require('mime-types');
+const exec = require('child_process').exec;
+const defaultContentType = 'application/javascript';
+
+const getContentType = function(filePath) {
+  return mime.lookup(filePath) || defaultContentType;
+}
+
+const run = function (cmd) {
+  return new Promise(function (resolve, reject) {
+    exec(cmd, function (error, stdout, stderr) {
+      if (error) {
+        reject(error);
+      }
+      if (stdout) {
+        console.log(stdout);
+      }
+      if (stderr) {
+        console.log(stderr);
+      }
+      resolve(stdout, stderr);
+    });
+  });
+}
+
+
+/**
+ * @param {Object} config
+ * @param {S3} config.s3 - aws s3 instance
+ * @param {Array} config.files - array of file paths to upload
+ * @param {String} config.dir - directory to upload all files from
+ * @param {String} config.destination - name of s3 directory to upload to
+ * @param {Number|String} config.version - version number
+ * @param {Boolean} [true] config.latest - whether to upload /latest file
+ */
+
+const Uploader = function(config) {
+  this.config = Object.assign({}, {
+    latest: true,
+  }, config);
+  if (config.files) {
+    this.filePaths = files;
+  }
+  if (config.dir) {
+    this.filePaths = fs.readdirSync(config.dir).map(function (file) {
+      return config.dir + '/' + file;
+    });
+  }
+}
+
+Uploader.prototype.deployStaticFiles = function () {
+  return Promise.all(this.filePaths.map(function (filePath) {
+    const uploadPaths = [];
+    const basename = path.basename(filePath);
+    const contents = fs.readFileSync(filePath);
+
+    if (this.config.version) {
+      uploadPaths.push(this.config.destination + '/' + this.config.version + '/' + basename);
+      if (this.config.latest) {
+        uploadPaths.push(this.config.destination + '/latest/' + basename);
+      }
+    } else {
+      uploadPaths.push(this.config.destination + '/' + basename);
+    }
+
+    return Promise.all(uploadPaths.map(function (uploadPath) {
+      return this.deployStaticFile(this.config.dir + '/' + basename, uploadPath);
+    }.bind(this)));
+  }.bind(this)));
+}
+
+Uploader.prototype.deployStaticFile = function(filePath, destination) {
+  return this.config.s3.putObject({
+    body: fs.readFileSync(filePath),
+    key: destination,
+    contentType: getContentType(filePath),
+  }).promise().then(function (data) {
+    console.info('Uploaded "' + filePath + '" to S3 as "' + s3Key + '"');
+    return data;
+  }, function (error) {
+    if(error) {
+      throw new Error('Error uploading ' + filePath, error);
+    }
+  });
+}
+
+Uploader.prototype.purgeStaticFiles = function () {
+  return Promise.all(this.filePaths.map(function (filePath) {
+    return this.purgeStaticFile(filePath);
+  }.bind(this)));
+}
+
+Uploader.prototype.purgeStaticFile = function(assetUrl, headers) {
+  if (!headers) headers = {};
+
+  return new Promise(function (resolve, reject) {
+    request({
+      method: 'PURGE',
+      url: assetUrl,
+      headers: headers
+    }, function(error) {
+      if (error) {
+        return reject('Error purging ' + assetUrl, error);
+      }
+      console.info('Purged ' + assetUrl);
+      return resolve();
+    })
+  })
+}
+
+Uploader.prototype.npmPublish = function () {
+  return run('npm install').then(function (stdout, stderr) {
+    return run ('npm publish');
+  }).catch(function (err) {
+    console.log(err);
+    return false;
+  });
+}
+
+module.exports = Uploader;


### PR DESCRIPTION
we now have versions of my original upload script across at least 4 repos. Time to squish it all into an `Uploader` class that can be customized through config options. 

I should probably add tests for this because it is not very good. 

Once this is merged we should use the same script across buy-button-storefront, js-buy-sdk, and whatever @stevebosworth was using s3 for. 

@tanema @richgilbank @minasmart @stevebosworth 