### PR TITLE
Cart animation fix

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -288,7 +288,7 @@ export default class Cart extends Component {
   _animateRemoveItem(id) {
     const el = this.document.getElementById(id);
     addClassToElement('is-hidden', el);
-    if (this.props.browserFeatures.transition) {
+    if (this.props.browserFeatures.animation) {
       el.addEventListener('animationend', () => {
         if (!el.parentNode) {
           return;

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -289,9 +289,7 @@ export default class Cart extends Component {
     const el = this.document.getElementById(id);
     addClassToElement('is-hidden', el);
     if (this.props.browserFeatures.transition) {
-      el.addEventListener('transitionend', () => {
-        // eslint-disable-next-line
-        // TODO: why is transitionend sometimes called twice?
+      el.addEventListener('animationend', () => {
         if (!el.parentNode) {
           return;
         }

--- a/src/styles/embeds/sass/components/_cart.scss
+++ b/src/styles/embeds/sass/components/_cart.scss
@@ -1,18 +1,30 @@
 $cart-item-height: 65px;
 
-@keyframes flipin {
+@keyframes flipIn {
   from {
     max-height: 0;
     transform: rotatex(90deg) translatey(-50%);
-    margin-bottom: -65px;
+    margin-bottom: -($cart-item-height);
     opacity: 0;
   }
 
   to {
-    min-height: $cart-item-height;
-    margin-bottom: $gutter;
     transform: none;
     opacity: 1;
+  }
+}
+
+@keyframes flipOut {
+  from {
+    transform: none;
+    opacity: 1;
+  }
+
+  to {
+    max-height: 0;
+    transform: rotatex(90deg) translatey(-50%);
+    margin-bottom: -($cart-item-height);
+    opacity: 0;
   }
 }
 
@@ -69,18 +81,13 @@ $cart-item-height: 65px;
   margin-bottom: 20px;
   overflow: hidden;
   position: relative;
-  transition: all 200ms;
   backface-visibility: visible;
   transform-style: preserve-3d;
-  animation-name: flipIn;
-  animation-duration: 200ms;
+  animation: 200ms flipIn forwards;
 }
 
 .shopify-buy__cart-item.is-hidden {
-  transform: rotateX(90deg) translateY(-50%);
-  margin-bottom: -65px;
-  opacity: 0;
-  transition: all 200ms;
+  animation-name: flipOut;
 }
 
 .shopify-buy__cart-item__image {

--- a/src/styles/embeds/sass/components/_cart.scss
+++ b/src/styles/embeds/sass/components/_cart.scss
@@ -82,7 +82,6 @@ $cart-item-height: 65px;
   overflow: hidden;
   position: relative;
   backface-visibility: visible;
-  transform-style: preserve-3d;
   animation: 200ms flipIn forwards;
 }
 

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -102,7 +102,7 @@ describe('Cart class', () => {
 
     it('calls updateLineItem', () => {
       cart._animateRemoveItem(123);
-      assert.calledWith(node.addEventListener, 'transitionend');
+      assert.calledWith(node.addEventListener, 'animationend');
     });
   });
 
@@ -196,4 +196,3 @@ describe('Cart class', () => {
     });
   });
 });
-


### PR DESCRIPTION
Fix https://github.com/Shopify/buy-button/issues/2020

1. Fix the typo that broke the add item animation (`flipin` to `flipIn`)
2. Refactor out animation for remove item as `flipOut` (and totally on purpose cuz I was flip out over css animation)
3. remove `transform-style: preserve-3d;` as it break cart look & feel for firefox 49.0.2

@harisaurus @tessalt @richgilbank 