### PR TITLE
add in safari prefix to fix safari flex box issue

### DIFF
--- a/src/styles/embeds/sass/components/_collection.scss
+++ b/src/styles/embeds/sass/components/_collection.scss
@@ -3,6 +3,7 @@
 }
 
 .shopify-buy__collection-products {
+  display: -webkit-box;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;


### PR DESCRIPTION
Because autoprefix is on hold,
this will fix Safari layout for now.

Before:
![screen shot 2016-11-10 at 1 42 56 pm](https://cloud.githubusercontent.com/assets/1610169/20189673/42df2f64-a74c-11e6-872a-b17ad0fb2206.png)

After:
![screen shot 2016-11-10 at 1 43 04 pm](https://cloud.githubusercontent.com/assets/1610169/20189680/48bee212-a74c-11e6-8c0e-b43ab3f1197f.png)

@harisaurus @tessalt 
