### PR TITLE
[DO NOT MERGE] Money format decode

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -29,7 +29,7 @@ export default class Component {
     this.node = config.node;
     this.globalConfig = {
       debug: config.debug,
-      moneyFormat: config.moneyFormat || defaultMoneyFormat,
+      moneyFormat: decodeURIComponent(config.moneyFormat) || defaultMoneyFormat,
       cartNode: config.cartNode,
       modalNode: config.modalNode,
       toggles: config.toggles,


### PR DESCRIPTION
First part fix for https://github.com/Shopify/buy-button/issues/2027

Tested with the currency moneyFormat string (ie. £{{amount}})
and URI encoded format string (ie. %C2%A3%7B%7Bamount%7D%7D)

Both works!

@harisaurus @tessalt 

This depend on https://github.com/Shopify/buy-button-js/pull/299 for some edge case detecting.