### PR TITLE
add a wrapper element to buttons to properly control alignment

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -46,6 +46,7 @@ const defaults = {
       imgWrapper: 'shopify-buy__product-img-wrapper',
       blockButton: 'shopify-buy__btn--parent',
       button: 'shopify-buy__btn',
+      buttonWrapper: 'shopify-buy__btn-wrapper',
       title: 'shopify-buy__product__title',
       prices: 'shopify-buy__product__price',
       price: 'shopify-buy__product__actual-price',

--- a/src/styles/embeds/sass/components/_product.scss
+++ b/src/styles/embeds/sass/components/_product.scss
@@ -118,8 +118,7 @@
 
   .shopify-buy__layout-vertical & {
     max-width: 280px;
-    margin-left: auto;
-    margin-right: auto;
+    display: inline-block;
   }
 }
 
@@ -141,7 +140,11 @@
 }
 
 .shopify-buy__btn {
-  display: block;
+  display: inline-block;
+}
+
+.shopify-buy__btn-wrapper {
+  margin-top: $gutter;
 }
 
 .shopify-buy__btn.shopify-buy__beside-quantity {
@@ -162,6 +165,13 @@
 
   .shopify-buy__quantity-container {
     display: inline-block;
+    vertical-align: top;
+  }
+
+  .shopify-buy__btn-wrapper {
+    display: inline-block;
+    vertical-align: top;
+    margin: 0;
   }
 }
 
@@ -215,8 +225,8 @@
     .shopify-buy__product__variant-title,
     .shopify-buy__product__price,
     .shopify-buy__product-description,
-    .shopify-buy__btn:not(.shopify-buy__beside-quantity),
     .shopify-buy__btn-and-quantity,
+    > .shopify-buy__btn-wrapper,
     > .shopify-buy__quantity-container,
     .shopify-buy__product__variant-selectors {
       margin-left: calc(40% + #{$gutter-modal});
@@ -236,8 +246,8 @@
     .shopify-buy__product__variant-title,
     .shopify-buy__product__price,
     .shopify-buy__product-description,
-    .shopify-buy__btn:not(.shopify-buy__beside-quantity),
     .shopify-buy__btn-and-quantity,
+    > .shopify-buy__btn-wrapper,
     > .shopify-buy__quantity-container,
     .shopify-buy__product__variant-selectors {
       margin-left: calc(60% + #{$gutter-modal});

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -9,7 +9,7 @@ const quantityTemplate = `<div class="{{data.classes.product.quantity}} {{data.q
               <button class="{{data.classes.product.quantityButton}} {{data.classes.product.quantityIncrement}}" type="button"><span>+</span><span class="visuallyhidden">Increment</span></button>
             {{/data.contents.quantityIncrement}}
            </div>`;
-const buttonTemplate = '<button {{#data.buttonDisabled}}disabled{{/data.buttonDisabled}} class="{{data.classes.product.button}} {{data.buttonClass}}">{{data.buttonText}}</button>';
+const buttonTemplate = '<div class="{{data.classes.product.buttonWrapper}}"><button {{#data.buttonDisabled}}disabled{{/data.buttonDisabled}} class="{{data.classes.product.button}} {{data.buttonClass}}">{{data.buttonText}}</button></div>';
 
 const productTemplate = {
   img: '<div class="{{data.classes.product.imgWrapper}}"><img class="{{data.classes.product.img}}" src="{{data.currentImage.src}}" /></div>',


### PR DESCRIPTION
- Add a wrapper to the button template
- Update styles to accomodate the above mentioned changes

These changes allow us to set the `text-alignment` on the product wrapper and align all the elements inside to the left/center/right.

@tessalt @tanema @michelleyschen 

a 🎩  would be appreciated

Examples:
![image](https://cloud.githubusercontent.com/assets/6800875/20192197/e0e2d058-a756-11e6-845d-751af682b345.png)

![image](https://cloud.githubusercontent.com/assets/6800875/20192255/198e60a2-a757-11e6-9595-a27b6acef16f.png)

![image](https://cloud.githubusercontent.com/assets/6800875/20192548/51e3711c-a758-11e6-9ed4-eb7f21be9121.png)
