### PR TITLE
Don't try to track failed embeds

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -208,11 +208,12 @@ export default class Component {
       this._userEvent('afterInit');
       return this;
     })
-    .catch((error) => {
-      if (error.message.indexOf('Not Found') > -1) {
+    .catch((err) => {
+      if (err.message.indexOf('Not Found') > -1) {
         logNotFound(this);
+      } else {
+        throw err;
       }
-      throw error;
     });
   }
 

--- a/src/component.js
+++ b/src/component.js
@@ -208,12 +208,11 @@ export default class Component {
       this._userEvent('afterInit');
       return this;
     })
-    .catch((err) => {
-      if (err.message.indexOf('Not Found') > -1) {
+    .catch((error) => {
+      if (error.message.indexOf('Not Found') > -1) {
         logNotFound(this);
-      } else {
-        throw err;
       }
+      throw error;
     });
   }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -64,7 +64,13 @@ export default class UI {
       this._bindEsc(component.iframe.el.contentWindow || component.iframe.el);
     }
     this.components[type].push(component);
-    return component.init().then(() => this.trackComponent(type, component));
+    return component.init().then(() => {
+      return this.trackComponent(type, component);
+    }).catch((error) => {
+      if (this.errorReporter) {
+        this.errorReporter.notifyException(error);
+      }
+    });
   }
 
   trackComponent(type, component) {


### PR DESCRIPTION
currently, tracker throws if a product does not exist because it tries to access properties on nonexistent model. Should catch those and report. 

@michelleyschen @tanema @harisaurus 