### PR TITLE
add additional tracking props

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -40,7 +40,7 @@ export default class UI {
       toggle: CartToggle,
     };
     this.errorReporter = integrations.errorReporter;
-    this.tracker = new Tracker(integrations.tracker);
+    this.tracker = new Tracker(integrations.tracker, this.client.config);
     this.styleOverrides = styleOverrides;
     this.tracker.trackPageview();
     this.activeEl = null;

--- a/src/utils/track.js
+++ b/src/utils/track.js
@@ -1,6 +1,7 @@
 export default class Tracker {
-  constructor(lib) {
+  constructor(lib, clientConfig) {
     this.lib = lib || null;
+    this.clientConfig = clientConfig;
   }
 
   trackMethod(fn, event, properties) {
@@ -49,7 +50,9 @@ export default class Tracker {
   }
 
   track(eventName, properties) {
-    properties.pageurl = document.referrer;
+    properties.pageurl = document.location.href;
+    properties.referrer = document.referrer;
+    properties.subdomain = this.clientConfig.domain;
     if (this.lib && this.lib.track) {
       this.lib.track(eventName, properties);
     }


### PR DESCRIPTION
adds `referrer` and `subdomain` fields to properties sent to trekkie.

@zqureshi @richgilbank @tanema @michelleyschen 