### PR TITLE
Support multi domain

### DIFF
--- a/src/buybutton.js
+++ b/src/buybutton.js
@@ -5,13 +5,14 @@ import productTemplates from './templates/product';
 window.ShopifyBuy = window.ShopifyBuy || ShopifyBuy;
 
 ShopifyBuy.UI = window.ShopifyBuy.UI || {
-  ui: null,
+  uis: {},
 
   init(client, integrations = {}, styleOverrides) {
-    if (!this.ui) {
-      this.ui = new UI(client, integrations, styleOverrides);
+    const domain = client.config.domain;
+    if (!this.uis[domain]) {
+      this.uis[domain] = new UI(client, integrations, styleOverrides);
     }
-    return this.ui;
+    return this.uis[domain];
   },
 
   adapterHelpers: {
@@ -19,8 +20,6 @@ ShopifyBuy.UI = window.ShopifyBuy.UI || {
       product: productTemplates,
     },
   },
-
-  UIConstructor: UI,
 };
 
 export default ShopifyBuy;

--- a/src/buybutton.js
+++ b/src/buybutton.js
@@ -5,14 +5,14 @@ import productTemplates from './templates/product';
 window.ShopifyBuy = window.ShopifyBuy || ShopifyBuy;
 
 ShopifyBuy.UI = window.ShopifyBuy.UI || {
-  uis: {},
+  domains: {},
 
   init(client, integrations = {}, styleOverrides) {
     const domain = client.config.domain;
-    if (!this.uis[domain]) {
-      this.uis[domain] = new UI(client, integrations, styleOverrides);
+    if (!this.domains[domain]) {
+      this.domains[domain] = new UI(client, integrations, styleOverrides);
     }
-    return this.uis[domain];
+    return this.domains[domain];
   },
 
   adapterHelpers: {

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -35,6 +35,15 @@ export default class Cart extends Component {
     });
   }
 
+  createToggles(config) {
+    this.toggles = this.toggles.concat(config.toggles.map((toggle) => {
+      return new CartToggle(merge({}, config, toggle), Object.assign({}, this.props, {cart: this}));
+    }));
+    return Promise.all(this.toggles.map((toggle) => {
+      return toggle.init({lineItems: this.model.lineItems});
+    }));
+  }
+
   /**
    * get key for configuration object.
    * @return {String}

--- a/src/ui.js
+++ b/src/ui.js
@@ -106,6 +106,11 @@ export default class UI {
    */
   createCart(config) {
     if (this.components.cart.length) {
+      if (config.toggles && config.toggles.length > this.components.cart[0].toggles.length) {
+        return this.components.cart[0].createToggles(config).then(() => {
+          return this.components.cart[0];
+        });
+      }
       return Promise.resolve(this.components.cart[0]);
     } else {
       const cart = new Cart(config, this.componentProps);


### PR DESCRIPTION
supports multiple domains on the same page. While you'll end up with 2 carts, if you're sending people straight to checkout it works fine.

changing the reference to UI instance(s) from `ui` to `domains` and it is now a hash not an object. Doesn't break the API because `init` still returns the most recently created instance.  

@tanema @harisaurus @michelleyschen 