### PR TITLE
force cart toggle to not re-calculate height.

### DIFF
--- a/src/components/toggle.js
+++ b/src/components/toggle.js
@@ -39,6 +39,10 @@ export default class CartToggle extends Component {
     return true;
   }
 
+  get outerHeight() {
+    return `${this.wrapper.clientHeight}px`;
+  }
+
   get stickyClass() {
     return this.options.sticky ? 'is-sticky' : 'is-inline';
   }


### PR DESCRIPTION
Fix https://github.com/Shopify/buy-button/issues/2050

@harisaurus @tessalt @tanema 

