### PR TITLE
update the cart total text to be subtotal and in call cap

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -206,7 +206,7 @@ const defaults = {
       title: 'Cart',
       empty: 'Your cart is empty.',
       button: 'CHECKOUT',
-      total: 'Total',
+      total: 'SUBTOTAL',
       currency: 'CAD',
       notice: 'Shipping and discount codes are added at checkout.',
     },


### PR DESCRIPTION
To address @richgilbank comment https://github.com/Shopify/buy-button-js/pull/315
@andreygargul requested that all button text to stay all cap,
and the total text to be update to `SUBTOTAL` and in all cap.

@harisaurus @tessalt @tanema 