### PR TITLE
enable button on out of stock if modal

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -205,6 +205,9 @@ export default class Product extends Component {
   }
 
   get buttonText() {
+    if (this.options.buttonDestination === 'modal') {
+      return this.options.text.button;
+    }
     if (!this.variantExists) {
       return this.options.text.unavailable;
     }
@@ -215,7 +218,7 @@ export default class Product extends Component {
   }
 
   get buttonEnabled() {
-    return this.buttonActionAvailable && this.variantExists && this.variantInStock;
+    return this.options.buttonDestination === 'modal' || (this.buttonActionAvailable && this.variantExists && this.variantInStock);
   }
 
   get variantExists() {


### PR DESCRIPTION
fixes https://github.com/Shopify/buy-button/issues/2080

button should never be disabled if it is linking to modal. 

@tanema @harisaurus @michelleyschen 