### PR TITLE
resize after is-active class get added

### DIFF
--- a/src/components/toggle.js
+++ b/src/components/toggle.js
@@ -84,6 +84,7 @@ export default class CartToggle extends Component {
     } else {
       this.iframe.removeClass('is-active');
     }
+    this.resize();
   }
 
   _resizeX() {


### PR DESCRIPTION
Fix https://github.com/Shopify/buy-button/issues/2082

This bug is cause by the fact that `resize` is usually call in the render step, and in terms of `toggle`, its get resize before the `is-active` class is apply. 
This mean the button has `display:none` on its iframe wrapper, and the dom element inside the iframe will calculate to 0px in Firefox, but in Chrome calculate it correctly.

To resolve it, I am forcing a `resize` after the class has been applied. 

@harisaurus @tanema @richgilbank @tessalt 