### PR TITLE
fix line item images for old carts

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -76,7 +76,7 @@ export default class Cart extends Component {
     return this.model.lineItems.reduce((acc, lineItem) => {
       const data = merge(lineItem, this.options.viewData);
       data.classes = this.classes;
-      data.lineItemImage = data.imageVariants.filter((image) => image.name === 'compact')[0] || {src: NO_IMG_URL};
+      data.lineItemImage = this.imageForLineItem(data);
       data.variantTitle = data.variant_title === 'Default Title' ? '' : data.variant_title;
       data.formattedPrice = formatMoney(data.line_price, this.globalConfig.moneyFormat);
       return acc + this.childTemplate.render({data}, (output) => `<div id="${lineItem.id}" class=${this.classes.lineItem.lineItem}>${output}</div>`);
@@ -115,6 +115,13 @@ export default class Cart extends Component {
 
   get wrapperClass() {
     return this.isVisible ? 'is-active' : '';
+  }
+
+  imageForLineItem(lineItem) {
+    if (!lineItem.imageVariants) {
+      return lineItem.image;
+    }
+    return lineItem.imageVariants.filter((image) => image.name === 'compact')[0] || {src: NO_IMG_URL};
   }
 
   /**


### PR DESCRIPTION
if you  had a cart in localStorage, the new `lineItem.imageVariants` field wouldn't be populated. This checks to see if it exists before using it. 

@michelleyschen @harisaurus 