### PR TITLE
switch creation order of components

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -111,15 +111,15 @@ export default class ProductSet extends Component {
       options: this.config,
     });
 
-    return super.init.call(this, data).then((model) => (
-      this.props.createCart(cartConfig).then((cart) => {
-        this.cart = cart;
+    return this.props.createCart(cartConfig).then((cart) => {
+      this.cart = cart;
+      return super.init.call(this, data).then((model) => {
         if (model) {
           return this.renderProducts(this.model.products);
         }
         return this;
-      })
-    ));
+      });
+    });
   }
 
   /**

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -454,15 +454,15 @@ export default class Product extends Component {
    * @return {Promise} promise resolving to instance.
    */
   init(data) {
-    return super.init.call(this, data).then((model) => (
-      this.createCart().then((cart) => {
-        this.cart = cart;
+    return this.createCart().then((cart) => {
+      this.cart = cart;
+      return super.init.call(this, data).then((model) => {
         if (model) {
           this.view.render();
         }
         return model;
-      })
-    ));
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
so i think https://github.com/Shopify/buy-button/issues/2121 is happening because sometimes the product set creates the cart first instead of the product, because the cart is created after the ajax request. This was to try to get data back as soon as possible, but we should keep the synchronous tasks running first so they run in order. Hard to test this.... but i couldn't reproduce the error locally and i had been able to occasionally before.

@michelleyschen @harisaurus 