### PR TITLE
dont try to track empty models

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -365,6 +365,9 @@ export default class Product extends Component {
    * @return {Object}
    */
   get trackingInfo() {
+    if (!this.model.selectedVariant) {
+      return {};
+    }
     return {
       id: this.id,
       name: this.model.selectedVariant.productTitle,


### PR DESCRIPTION
so i'm getting a lot of errors in bugsnag for `Cannot read property 'productTitle' of undefined` coming from line 373. All instances are for attempts to retrieve products that don't exist... but `trackingInfo` should never be called in those cases and I haven't been able to trigger the bug even under the conditions bugsnag reports. 

Anyways, this should shut that up, at least. 

