### PR TITLE
update docs with popup cart option

### DIFF
--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -254,6 +254,14 @@ Whether cart should be visible or not when initialized.
 
 **Default value**: `false`
 
+### `popup`
+
+Whether or not the checkout process is in a pop-up or the same window.
+
+**Type**: Boolean
+
+**Default value**: `false`
+
 ### Cart contents defaults
 
 ```js

--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -260,7 +260,7 @@ Whether or not the checkout process is in a pop-up or the same window.
 
 **Type**: Boolean
 
-**Default value**: `false`
+**Default value**: `true`
 
 ### Cart contents defaults
 


### PR DESCRIPTION
I was looking for the possibility to proceed to the checkout within the same window. After studying the code I found this undocumented option which is [checked](https://github.com/Shopify/buy-button-js/blob/2b1791de3d5f49eed55f5c1074cd980a77e5f603/src/components/checkout.js#L16) in the Checkout.js.