### PR TITLE
don't swallow errors

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -168,9 +168,8 @@ export default class Component {
     .catch((err) => {
       if (err.message.indexOf('Not Found') > -1) {
         logNotFound(this);
-      } else {
-        throw err;
       }
+      throw err;
     });
   }
 


### PR DESCRIPTION
through a long chain of unfortunate complex things, this swallowed error was causing the "Not found" error to be incorrectly reported to bugsnag as `Cannot read property 'productTitle' of undefined`

@tanema @michelleyschen @harisaurus 