### PR TITLE
wait for fontactive to render

### DIFF
--- a/src/iframe.js
+++ b/src/iframe.js
@@ -113,15 +113,23 @@ export default class iframe {
       return Promise.resolve(true);
     }
     return this.loadFontScript().then(() => {
-      if (window.WebFont) {
+      return new Promise((resolve) => {
+        if (!window.WebFont) {
+          return resolve();
+        }
         window.WebFont.load({
           google: {
             families: this.googleFonts,
           },
+          fontactive: () => {
+            return resolve();
+          },
           context: this.el.contentWindow || frames[this.name],
         });
-      }
-      return true;
+        return window.setTimeout(() => {
+          return resolve();
+        }, 1000);
+      });
     });
   }
 


### PR DESCRIPTION
this was a bit of a weird one. Basically there are multiple states of a font being loaded in the webfont loader, and until the final state ("active"), safari can't accurately calculate an element's width, leading to bugs like https://github.com/Shopify/buy-button/issues/2134 

http://stackoverflow.com/questions/4701892/accurate-width-of-element-when-using-font-face-in-chromium

So ive changed it so that the promise for loading fonts is resolved only when the `fontactive` event fires (or after 1 second if it never fires).

@michelleyschen @harisaurus @tanema 