### PR TITLE
hide the image wrapper if no image is present

### DIFF
--- a/src/styles/embeds/sass/components/product.css
+++ b/src/styles/embeds/sass/components/product.css
@@ -264,6 +264,12 @@
   }
 }
 
+.no-image {
+  & .shopify-buy__product-img-wrapper {
+    display: none;
+  }
+}
+
 @keyframes dash {
   to {
     stroke-dashoffset: 0;


### PR DESCRIPTION
A broken image icon currently appears on older versions of Firefox when no-image is present (https://github.com/Shopify/buy-button/issues/2138). It also causes the iframe to size incorrectly. This PR addresses the issue by hiding the image wrapper when `no-image` is present.


**Before**
![image](https://cloud.githubusercontent.com/assets/6800875/22746498/df89d5d0-edf1-11e6-8066-32f19bec15a0.png)


**After**
![image](https://cloud.githubusercontent.com/assets/6800875/22746479/c98c9eca-edf1-11e6-8044-0b422f5c43db.png)
