### PR TITLE
add default positioning for image with carousel for product

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -15,6 +15,7 @@ const defaults = {
     width: '280px',
     order: [
       'img',
+      'imgWithCarousel',
       'title',
       'variantTitle',
       'price',


### PR DESCRIPTION
Provide `imgWithCarousel` a position in the template order otherwise the featured layout doesn't know where to render the carousel version (therefore not rendering it at all).