### PR TITLE
Adding screenreader functionality to the cart toggle

### DIFF
--- a/src/styles/embeds/sass/utilities.css
+++ b/src/styles/embeds/sass/utilities.css
@@ -1,3 +1,13 @@
 .shopify-buy__type--center {
   text-align: center;
 }
+
+.shopify-buy--visually-hidden {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding:0 !important;
+  border:0 !important;
+  height: 1px !important;
+  width: 1px !important;
+  overflow: hidden;
+}

--- a/src/views/toggle.js
+++ b/src/views/toggle.js
@@ -62,7 +62,7 @@ export default class ToggleView extends View {
   }
 
   wrapTemplate(html) {
-    return `<div role="button" class="${this.stickyClass} ${this.component.classes.toggle.toggle}">
+    return `<div class="${this.stickyClass} ${this.component.classes.toggle.toggle}">
       ${html}
       ${this.readableLabel}
     </div>`;

--- a/src/views/toggle.js
+++ b/src/views/toggle.js
@@ -23,6 +23,13 @@ export default class ToggleView extends View {
     return `${this.wrapper.clientHeight}px`;
   }
 
+  get readableLabel() {
+    if(this.component.options.contents.title) {
+      return '';
+    }
+    return `<p class="shopify-buy--visually-hidden">${this.component.options.text.title}</p>`;
+  }
+
   render() {
     super.render();
     if (this.component.options.sticky) {
@@ -35,6 +42,8 @@ export default class ToggleView extends View {
     }
     if (this.iframe) {
       this.iframe.parent.setAttribute('tabindex', 0);
+      this.iframe.parent.setAttribute('role', 'button');
+      this.iframe.parent.setAttribute('aria-label', this.component.options.text.title);
       this.resize();
     }
   }
@@ -53,7 +62,10 @@ export default class ToggleView extends View {
   }
 
   wrapTemplate(html) {
-    return `<div class="${this.stickyClass} ${this.component.classes.toggle.toggle}">${html}</div>`;
+    return `<div role="button" class="${this.stickyClass} ${this.component.classes.toggle.toggle}">
+      ${html}
+      ${this.readableLabel}
+    </div>`;
   }
 
   _resizeX() {

--- a/src/views/toggle.js
+++ b/src/views/toggle.js
@@ -24,7 +24,7 @@ export default class ToggleView extends View {
   }
 
   get readableLabel() {
-    if(this.component.options.contents.title) {
+    if (this.component.options.contents.title) {
       return '';
     }
     return `<p class="shopify-buy--visually-hidden">${this.component.options.text.title}</p>`;


### PR DESCRIPTION
fixes #371 

I did a few things to hopefully make it accessible however I am not an expert at these things so please let me know if something could have been done in a different way.

what I did.

- added `aria-label` to the toggle
- added `role='button'` to the toggle
- added a visibility-hidden text block that is present only when the title is not shown and using the title text.