### PR TITLE
use storefrontId rather than id in Product class

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -23,6 +23,7 @@ export default class Component {
    */
   constructor(config, props) {
     this.id = config.id;
+    this.storefrontId = config.storefrontId;
     this.handle = config.handle;
     this.node = config.node;
     this.globalConfig = {

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -75,7 +75,7 @@ export default class Product extends Component {
    * @param {Object} props - data and utilities passed down from UI instance.
    */
   constructor(config, props) {
-    config.id = normalizeProductId(config);
+    config.storefrontId = normalizeProductId(config);
     super(config, props);
     this.typeKey = 'product';
     this.defaultVariantId = config.variantId;
@@ -534,8 +534,8 @@ export default class Product extends Component {
    * @return {Promise} promise resolving to model data.
    */
   sdkFetch() {
-    if (this.id) {
-      return this.props.client.fetchProduct(this.id);
+    if (this.storefrontId) {
+      return this.props.client.fetchProduct(this.storefrontId);
     } else if (this.handle) {
       return this.props.client.fetchProductByHandle(this.handle).then((product) => product);
     }
@@ -550,7 +550,7 @@ export default class Product extends Component {
   fetchData() {
     return this.sdkFetch().then((model) => {
       if (model) {
-        this.id = model.id;
+        this.storefrontId = model.id;
         this.handle = model.handle;
         return model;
       }

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -69,7 +69,7 @@ describe('Product class', () => {
     product = new Product({
       id: 123
     }, props);
-    assert.equal(product.id, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMw==')
+    assert.equal(product.storefrontId, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMw==')
   })
 
   describe('init', () => {


### PR DESCRIPTION
change the property names to be more clear about when we are using a storefrontId rather than a shopify product id

addresses #405