### PR TITLE
Fix typo in readme about installing jekyll

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Will watch for changes and run test suite.
 To run docs locally, install jekyll:
 
 ```
-gem intsall jekyll
+gem install jekyll
 ```
 
 ```


### PR DESCRIPTION
Fix typo in readme by replacing `intsall` with
`install`.