### PR TITLE
Various fixes

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: buy-button-js
 
 up:
   - node:
-      version: v6.9.5
+      version: v7.10.1
       yarn: true
 
 commands:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@shopify/buy-button-js",
   "version": "0.4.13",
   "description": "BuyButton.js allows merchants to build Shopify interfaces into any website",
-  "main": "lib/buybutton.cjs.js",
+  "main": "lib/buybutton.umd.js",
   "repository": "git@github.com:Shopify/buy-button-js.git",
   "scripts": {
     "start": "rm -rf tmp && mkdir tmp && yarn run src:watch & yarn run styles:watch & yarn run serve",
@@ -93,7 +93,7 @@
     "morphdom": "1.4.6",
     "mustache": "2.2.1",
     "node-sass": "3.8.0",
-    "shopify-buy": "1.0.0-alpha.11",
+    "shopify-buy": "1.0.0-alpha.12",
     "uglify-js": "2.7.0"
   }
 }

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -317,10 +317,13 @@ export default class Cart extends Component {
    * Remove all lineItems in the cart
    */
   empty() {
-    return this.model.clearLineItems().then(() => {
+    const lineItemIds = this.model.lineItems ? this.model.lineItems.map((item) => item.id) : [];
+
+    return this.props.client.removeLineItems(this.model.id, lineItemIds).then((checkout) => {
+      this.model = checkout;
       this.view.render();
       this.toggles.forEach((toggle) => toggle.view.render());
-      return;
+      return checkout;
     });
   }
 

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -128,13 +128,20 @@ export default class Product extends Component {
     if (!(this.selectedVariant || this.options.contents.imgWithCarousel)) {
       return null;
     }
-    const imageSize = parseInt(this.options.width, 10) || 480;
+
+    let imageSize;
+    if (this.options.width && this.options.width.slice(-1) === '%') {
+      imageSize = 1000;
+    } else {
+      imageSize = parseInt(this.options.width, 10) || 480;
+    }
+
     let src;
     let id;
 
     const imageOptions = {
       maxWidth: imageSize,
-      maxHeight: imageSize,
+      maxHeight: imageSize * 1.5,
     };
 
     if (this.selectedImage) {
@@ -203,6 +210,7 @@ export default class Product extends Component {
         id: image.id,
         src: image.src,
         carouselSrc: ShopifyBuy.Image.Helpers.imageForSize(image, {maxWidth: 100, maxHeight: 100}),
+        isSelected: image.id === this.currentImage.id,
       };
     });
   }

--- a/src/updaters/product.js
+++ b/src/updaters/product.js
@@ -41,11 +41,11 @@ export default class ProductUpdater extends Updater {
       this.component.view.iframe.removeClass(this.component.classes.product.vertical);
       this.component.view.iframe.removeClass(this.component.classes.product.horizontal);
       this.component.view.iframe.addClass(this.component.classes.product[layout]);
-      this.component.view.resizeUntilLoaded();
+      this.component.view.resize();
     }
     [...this.component.view.wrapper.querySelectorAll('img')].forEach((img) => {
       img.addEventListener('load', () => {
-        this.component.view.resizeUntilLoaded();
+        this.component.view.resize();
       });
     });
     super.updateConfig(config);

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -181,14 +181,14 @@ describe('Cart class', () => {
 
   describe('empty', () => {
     it('empties and rerenders the cart', () => {
-      cart.model = {
-        clearLineItems: sinon.stub().returns(Promise.resolve())
-      }
+      cart.props.client = {
+        removeLineItems: sinon.stub().returns(Promise.resolve()),
+      };
       cart.view.render = sinon.spy();
       cart.toggles[0].view.render = sinon.spy();
 
       return cart.empty().then(() => {
-        assert.calledOnce(cart.model.clearLineItems);
+        assert.calledOnce(cart.props.client.removeLineItems);
         assert.calledOnce(cart.view.render);
         assert.calledOnce(cart.toggles[0].view.render);
       });

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -234,7 +234,7 @@ describe('Product class', () => {
     describe('if variant exists', () => {
       it('returns selected image', () => {
         return product.init(testProductCopy).then(() => {
-          assert.equal(product.currentImage.src, rootImageURI + 'image-one_280x280.jpg');
+          assert.equal(product.currentImage.src, rootImageURI + 'image-one_280x420.jpg');
         });
       });
     });
@@ -243,7 +243,7 @@ describe('Product class', () => {
       it('returns cached image', () => {
         return product.init(testProductCopy).then(() => {
           product.selectedVariant = {};
-          assert.equal(product.currentImage.src, rootImageURI + 'image-one_280x280.jpg');
+          assert.equal(product.currentImage.src, rootImageURI + 'image-one_280x420.jpg');
         });
       });
     });
@@ -297,7 +297,7 @@ describe('Product class', () => {
         const viewData = product.viewData;
         assert.equal(viewData.buttonText, 'ADD TO CART');
         assert.ok(viewData.optionsHtml);
-        assert.equal(viewData.currentImage.src, rootImageURI + 'image-one_280x280.jpg');
+        assert.equal(viewData.currentImage.src, rootImageURI + 'image-one_280x420.jpg');
         assert.ok(viewData.hasVariants);
         assert.equal(viewData.test, 'test string');
       });
@@ -639,7 +639,7 @@ describe('Product class', () => {
       });
 
       it('returns true', () => {
-        product.cachedImage = rootImageURI + 'image-one_240x240.jpg'
+        product.cachedImage = rootImageURI + 'image-one_240x360.jpg'
         assert.notOk(product.shouldUpdateImage);
       });
     });
@@ -651,9 +651,9 @@ describe('Product class', () => {
         return product.init(testProductCopy);
       });
 
-      it('returns 480x480 image', () => {
+      it('returns 480x720 default image', () => {
         product.config.product.width = undefined;
-        assert.equal(product.image.src, rootImageURI + 'image-one_480x480.jpg');
+        assert.equal(product.image.src, rootImageURI + 'image-one_480x720.jpg');
       });
     });
 
@@ -663,7 +663,7 @@ describe('Product class', () => {
         return product.init(testProductCopy);
       });
       it('returns smallest image larger than explicit width', () => {
-        assert.equal(product.image.src, rootImageURI + 'image-one_160x160.jpg');
+        assert.equal(product.image.src, rootImageURI + 'image-one_160x240.jpg');
       });
     });
 
@@ -675,11 +675,11 @@ describe('Product class', () => {
         });
       });
       it('returns selected image', () => {
-        assert.equal(product.image.src, rootImageURI + 'image-three_280x280.jpg');
+        assert.equal(product.image.src, rootImageURI + 'image-three_280x420.jpg');
       });
       it('returns selected image of appropriate size if set', () => {
         product.config.product.width = '480px';
-        assert.equal(product.image.src, rootImageURI + 'image-three_480x480.jpg');
+        assert.equal(product.image.src, rootImageURI + 'image-three_480x720.jpg');
       })
     });
   });
@@ -692,13 +692,13 @@ describe('Product class', () => {
     });
     it('sets selected image based on various offsets', () => {
       product.onCarouselChange(-1);
-      assert.equal(product.image.src, rootImageURI + 'image-four_280x280.jpg');
+      assert.equal(product.image.src, rootImageURI + 'image-four_280x420.jpg');
       product.onCarouselChange(-1);
-      assert.equal(product.image.src, rootImageURI + 'image-three_280x280.jpg');
+      assert.equal(product.image.src, rootImageURI + 'image-three_280x420.jpg');
       product.onCarouselChange(1);
-      assert.equal(product.image.src, rootImageURI + 'image-four_280x280.jpg');
+      assert.equal(product.image.src, rootImageURI + 'image-four_280x420.jpg');
       product.onCarouselChange(1);
-      assert.equal(product.image.src, rootImageURI + 'image-one_280x280.jpg');
+      assert.equal(product.image.src, rootImageURI + 'image-one_280x420.jpg');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4712,9 +4712,9 @@ shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
-shopify-buy@1.0.0-alpha.11:
-  version "1.0.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.0.0-alpha.11.tgz#2c07621b8859f20fbd05be64602e73efe708d080"
+shopify-buy@1.0.0-alpha.12:
+  version "1.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.0.0-alpha.12.tgz#ea0e9833ee382ab06ad30ec6feab5d4997e420f0"
 
 sigmund@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- Update node version in `dev.yml`
- Bump jsbuysdk version for bugfixes
- `clearLineItems` no longer exists. Update to use `removeLineItems` for emptying cart
- Update image getter
  - Use 480 as default if no embed width is provided
  - If % width is provided, use 1000px instead. The % situation is most common for when creating full width embeds using 100%, so 1000px addresses all breakpoints
- Re-add `isSelected` to carousel images to show selected image