### PR TITLE
set storefront variant id when variant id is set + fixes

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -52,11 +52,11 @@ function whitelistedProperties(selectorStyles) {
   }, {});
 }
 
-function normalizeProductId(config) {
-  if (config.storefrontId) {
-    return config.storefrontId;
-  } else if (config.id) {
-    return btoa(`gid://shopify/Product/${config.id}`);
+function normalizeId(type, config, databaseKey, storefrontKey) {
+  if (config[storefrontKey]) {
+    return config[storefrontKey];
+  } else if (config[databaseKey]) {
+    return btoa(`gid://shopify/${type}/${config[databaseKey]}`);
   } else {
     return null;
   }
@@ -75,10 +75,12 @@ export default class Product extends Component {
    * @param {Object} props - data and utilities passed down from UI instance.
    */
   constructor(config, props) {
-    config.storefrontId = normalizeProductId(config);
+    config.storefrontId = normalizeId('Product', config, 'id', 'storefrontId');
+    config.storefrontVariantId = normalizeId('ProductVariant', config, 'variantId', 'storefrontVariantId');
+
     super(config, props);
     this.typeKey = 'product';
-    this.defaultVariantId = config.variantId;
+    this.defaultStorefrontVariantId = config.storefrontVariantId;
     this.cachedImage = null;
     this.childTemplate = new Template(this.config.option.templates, this.config.option.contents, this.config.option.order);
     this.cart = null;
@@ -725,11 +727,10 @@ export default class Product extends Component {
    */
   setDefaultVariant(model) {
     let selectedVariant;
-
-    if (this.defaultVariantId) {
-      selectedVariant = model.variants.find((variant) => variant.id === this.defaultVariantId);
+    if (this.defaultStorefrontVariantId) {
+      selectedVariant = model.variants.find((variant) => variant.id === this.defaultStorefrontVariantId);
     } else {
-      this.defaultVariantId = model.variants[0].id;
+      this.defaultStorefrontVariantId = model.variants[0].id;
       selectedVariant = model.variants[0];
       this.selectedImage = model.images[0];
     }

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -5,6 +5,7 @@ import Template from '../template';
 import Checkout from './checkout';
 import windowUtils from '../utils/window-utils';
 import formatMoney from '../utils/money';
+import normalizeConfig from '../utils/normalize-config';
 import ProductView from '../views/product';
 import ProductUpdater from '../updaters/product';
 
@@ -52,16 +53,6 @@ function whitelistedProperties(selectorStyles) {
   }, {});
 }
 
-function normalizeId(type, config, databaseKey, storefrontKey) {
-  if (config[storefrontKey]) {
-    return config[storefrontKey];
-  } else if (config[databaseKey]) {
-    return btoa(`gid://shopify/${type}/${config[databaseKey]}`);
-  } else {
-    return null;
-  }
-}
-
 /**
  * Renders and fetches data for product embed.
  * @extends Component.
@@ -75,8 +66,8 @@ export default class Product extends Component {
    * @param {Object} props - data and utilities passed down from UI instance.
    */
   constructor(config, props) {
-    config.storefrontId = normalizeId('Product', config, 'id', 'storefrontId');
-    config.storefrontVariantId = normalizeId('ProductVariant', config, 'variantId', 'storefrontVariantId');
+    // eslint-disable-next-line no-param-reassign
+    config = normalizeConfig(config);
 
     super(config, props);
     this.typeKey = 'product';

--- a/src/updaters/product.js
+++ b/src/updaters/product.js
@@ -4,9 +4,9 @@ const MAX_WIDTH = '950px';
 
 export default class ProductUpdater extends Updater {
   updateConfig(config) {
-    if (config.id || config.variantId) {
-      this.component.id = config.id || this.component.id;
-      this.component.defaultVariantId = config.variantId || this.component.defaultVariantId;
+    if (config.storefrontId || config.storefrontVariantId) {
+      this.component.id = config.storefrontId || this.component.storefrontId;
+      this.component.defaultStorefrontVariantId = config.storefrontVariantId || this.component.defaultStorefrontVariantId;
       this.component.init();
       return;
     }

--- a/src/updaters/product.js
+++ b/src/updaters/product.js
@@ -1,12 +1,14 @@
 import Updater from '../updater';
+import normalizeConfig from '../utils/normalize-config';
 
 const MAX_WIDTH = '950px';
 
 export default class ProductUpdater extends Updater {
   updateConfig(config) {
-    if (config.storefrontId || config.storefrontVariantId) {
-      this.component.id = config.storefrontId || this.component.storefrontId;
-      this.component.defaultStorefrontVariantId = config.storefrontVariantId || this.component.defaultStorefrontVariantId;
+    const newConfig = normalizeConfig(config);
+    if (newConfig.storefrontId || newConfig.storefrontVariantId) {
+      this.component.storefrontId = newConfig.storefrontId || this.component.storefrontId;
+      this.component.defaultStorefrontVariantId = newConfig.storefrontVariantId || this.component.defaultStorefrontVariantId;
       this.component.init();
       return;
     }

--- a/src/utils/normalize-config.js
+++ b/src/utils/normalize-config.js
@@ -1,0 +1,27 @@
+export function simpleNormalizeId(type, databaseKey) {
+  return btoa(`gid://shopify/${type}/${databaseKey}`);
+}
+
+export function getNormalizedIdFromConfig(type, config, databaseKey, storefrontKey) {
+  if (config[storefrontKey]) {
+    return config[storefrontKey];
+  } else if (config[databaseKey]) {
+    return simpleNormalizeId(type, config[databaseKey]);
+  } else {
+    return null;
+  }
+}
+
+function normalizeConfig(config) {
+  if (config.id || config.storefrontId) {
+    config.storefrontId = getNormalizedIdFromConfig('Product', config, 'id', 'storefrontId');
+  }
+
+  if (config.variantId || config.storefrontVariantId) {
+    config.storefrontVariantId = getNormalizedIdFromConfig('ProductVariant', config, 'variantId', 'storefrontVariantId');
+  }
+
+  return config;
+}
+
+export default normalizeConfig;

--- a/test/fixtures/product-fixture.js
+++ b/test/fixtures/product-fixture.js
@@ -1,6 +1,7 @@
 const testProduct = {
   title: 'test',
   id: 123,
+  storefrontId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMw==',
   images: [
     {
       id: 1,
@@ -39,7 +40,7 @@ const testProduct = {
   ],
   variants: [
     {
-      id: 12345,
+      id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==',
       productId: 123,
       price: '123.00',
       title: 'sloth / small',
@@ -60,7 +61,7 @@ const testProduct = {
       ]
     },
     {
-      id: 12346,
+      id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0Ng==',
       productId: 123,
       price: '1.00',
       title: 'shark / small',
@@ -81,7 +82,7 @@ const testProduct = {
       ]
     },
     {
-      id: 12347,
+      id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0Nw==',
       productId: 123,
       price: '999.99',
       title: 'shark / large',
@@ -102,7 +103,7 @@ const testProduct = {
       ]
     },
     {
-      id: 12348,
+      id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0OA==',
       productId: 123,
       price: '0.00',
       title: 'cat / small',

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -107,7 +107,7 @@ describe('Product class', () => {
     describe('if variant exists for selected options', () => {
       it('returns true', () => {
         return product.init(testProductCopy).then(() => {
-          product.selectedVariant = { id: 12345 };
+          product.selectedVariant = { id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==' };
           assert.isOk(product.variantExists);
         });
       });
@@ -202,7 +202,7 @@ describe('Product class', () => {
     describe('if variant is not in stock', () => {
       it('returns "out of stock"', () => {
         product.selectedVariant = {
-          id: 12345,
+          id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==',
           available: false,
         }
         assert.equal(product.buttonText, product.options.text.outOfStock);
@@ -430,7 +430,7 @@ describe('Product class', () => {
     });
   });
 
-  describe('when updating ID or variant ID', () => {
+  describe('when updating ID, storefront ID, variant ID, or storefront variant ID', () => {
     let initSpy;
 
     beforeEach(() => {
@@ -438,21 +438,33 @@ describe('Product class', () => {
     });
 
     it('calls init if ID updated', () => {
-      product.updateConfig({id: 7777});
+      product.updateConfig({id: 123});
       assert.calledOnce(initSpy);
-      assert.equal(product.id, 7777);
+      assert.equal(product.storefrontId, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMw==');
+    });
+
+    it('calls init if storefront ID updated', () => {
+      product.updateConfig({storefrontId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMw=='});
+      assert.calledOnce(initSpy);
+      assert.equal(product.storefrontId, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMw==');
     });
 
     it('calls init if variant ID updated', () => {
       product.updateConfig({variantId: 7777});
       assert.calledOnce(initSpy);
-      assert.equal(product.defaultVariantId, 7777);
+      assert.equal(product.defaultStorefrontVariantId, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC83Nzc3');
+    });
+
+    it('calls init if storefront variant ID updated', () => {
+      product.updateConfig({storefrontVariantId: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC83Nzc3'});
+      assert.calledOnce(initSpy);
+      assert.equal(product.defaultStorefrontVariantId, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC83Nzc3');
     });
   });
 
   describe('setDefaultVariant', () => {
-    it('sets selectedVariant to product.defalutVariantId', () => {
-      product.defaultVariantId = 12347;
+    it('sets selectedVariant\'s id to product.defaultVariantId', () => {
+      product.defaultStorefrontVariantId = 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0Nw==';
       const model = product.setDefaultVariant(testProduct);
       assert.equal(product.selectedOptions.Print, 'shark');
       assert.equal(product.selectedOptions.Size, 'large');
@@ -473,7 +485,7 @@ describe('Product class', () => {
     describe('when variant is out of stock', () => {
       it('returns out of stock text', () => {
         product.selectedVariant = {
-          id: 12345,
+          id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==',
           available: false,
         };
         assert.equal(product.buttonText, product.options.text.outOfStock);
@@ -482,7 +494,7 @@ describe('Product class', () => {
     describe('when variant is available', () => {
       it('returns button text', () => {
         product.selectedVariant = {
-          id: 12345,
+          id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==',
           available: true,
         };
         assert.equal(product.buttonText, product.options.text.button);


### PR DESCRIPTION
- normalize variant ids when present, and use normalized variant id instead of database key.
- a bunch of normalizers
- tiny fixes