### PR TITLE
prevent events from binding again on re-inits

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -13,6 +13,7 @@ export default class View {
     this.iframe = null;
     this.node = this.component.node;
     this.template = new Template(this.component.options.templates, this.component.options.contents, this.component.options.order);
+    this.eventsBound = false;
   }
 
   init() {
@@ -53,7 +54,12 @@ export default class View {
    * delegates DOM events to event listeners.
    */
   delegateEvents() {
+    if (this.eventsBound) {
+      return;
+    }
+
     this.closeComponentsOnEsc();
+
     Object.keys(this.component.DOMEvents).forEach((key) => {
       const [, eventName, selectorString] = key.match(delegateEventSplitter);
       if (selectorString) {
@@ -72,6 +78,8 @@ export default class View {
         this.reloadIframe();
       };
     }
+
+    this.eventsBound = true;
   }
 
   reloadIframe() {
@@ -264,6 +272,7 @@ export default class View {
   }
 
   _on(eventName, selector, fn) {
+
     this.wrapper.addEventListener(eventName, (evt) => {
       const possibleTargets = Array.prototype.slice.call(this.wrapper.querySelectorAll(selector));
       const target = evt.target;

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -108,6 +108,23 @@ describe('View class', () => {
       assert.calledWith(onStub, 'click', '.btn', sinon.match.func);
       assert.calledWith(view.wrapper.addEventListener, 'click', sinon.match.func);
     });
+
+    it('bind events if eventsBound is false', () => {
+      view.wrapper = {
+        addEventListener: sinon.spy()
+      }
+      view.delegateEvents();
+      assert.called(view.wrapper.addEventListener);
+    });
+
+    it('prevents rebinding if events already bound', () => {
+      view.wrapper = {
+        addEventListener: sinon.spy()
+      }
+      view.eventsBound = true;
+      view.delegateEvents();
+      assert.notCalled(view.wrapper.addEventListener);
+    });
   });
 
   describe('append()', () => {


### PR DESCRIPTION
Anytime the config is changed for an embed, `init` is called. This calls `delegateEvents` which would create event listeners for the required elements. This was an issue as multiple listeners were attached to the same elements over and over anytime the config was updated, which would cause crazy behaviour in the Buy Button app.

There should ideally be an `init` and a similar `update` method, the latter not rebinding events, but that would require a bunch of rework. Adding in the simpler, but not really elegant, solution as a flag that is checked before the events are bound.

Ping me for 🎩 -ing instructions to test buybuttonjs with buybutton.