### PR TITLE
add srcLarge for default horizontal layouts and update example

### DIFF
--- a/index.example.html
+++ b/index.example.html
@@ -9,9 +9,8 @@
     <script src="tmp/buybutton.dev.js"></script>
     <script data-shopify-buy-ui>
       var client = ShopifyBuy.buildClient({
-        apiKey: '',
         domain: '', // ex 'storename.myshopify.com'
-        appId: '6'
+        storefrontAccessToken: '' // previously 'apiKey', now deprecated
       });
 
       var ui = ShopifyBuy.UI.init(client);

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -117,6 +117,9 @@ export default class Product extends Component {
    * @return {Object} image object.
    */
   get image() {
+    const DEFAULT_IMAGE_SIZE = 480;
+    const MODAL_IMAGE_SIZE = 550;
+
     if (!(this.selectedVariant || this.options.contents.imgWithCarousel)) {
       return null;
     }
@@ -125,25 +128,33 @@ export default class Product extends Component {
     if (this.options.width && this.options.width.slice(-1) === '%') {
       imageSize = 1000;
     } else {
-      imageSize = parseInt(this.options.width, 10) || 480;
+      imageSize = parseInt(this.options.width, 10) || DEFAULT_IMAGE_SIZE;
     }
 
-    let src;
     let id;
+    let src;
+    let srcLarge;
 
     const imageOptions = {
       maxWidth: imageSize,
       maxHeight: imageSize * 1.5,
     };
 
+    const imageOptionsLarge = {
+      maxWidth: MODAL_IMAGE_SIZE,
+      maxHeight: MODAL_IMAGE_SIZE * 1.5,
+    };
+
     if (this.selectedImage) {
       id = this.selectedImage.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptions);
+      srcLarge = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptionsLarge);
     } else {
       id = this.selectedVariant.image.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptions);
+      srcLarge = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptionsLarge);
     }
-    return {id, src};
+    return {id, src, srcLarge};
   }
 
   /**

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -12,7 +12,7 @@ const quantityTemplate = `<div class="{{data.classes.product.quantity}} {{data.q
 const buttonTemplate = '<div class="{{data.classes.product.buttonWrapper}}" data-element="product.buttonWrapper"><button {{#data.buttonDisabled}}disabled{{/data.buttonDisabled}} class="{{data.classes.product.button}} {{data.buttonClass}}" data-element="product.button">{{data.buttonText}}</button></div>';
 
 const productTemplate = {
-  img: '<div class="{{data.classes.product.imgWrapper}}" data-element="product.imgWrapper"><img data-element="product.img" class="{{data.classes.product.img}}" src="{{data.currentImage.src}}" /></div>',
+  img: '<div class="{{data.classes.product.imgWrapper}}" data-element="product.imgWrapper"><img data-element="product.img" class="{{data.classes.product.img}}" src="{{data.currentImage.srcLarge}}" /></div>',
   imgWithCarousel: `<div class="{{data.classes.product.imgWrapper}}" data-element="product.imageWrapper">
                       <div class="main-image-wrapper">
                         <button type="button" class="carousel-button carousel-button--previous">

--- a/src/ui.js
+++ b/src/ui.js
@@ -23,7 +23,6 @@ export default class UI {
    */
   constructor(client, integrations = {}, styleOverrides = '') {
     this.client = client;
-    // this.config = config;
     this.config = {};
     this.config.domain = client.shop.fetchInfo().then((res) => {
       return res.attrs.primaryDomain.attrs.host.value;

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -640,7 +640,7 @@ describe('Product class', () => {
       });
 
       it('returns true', () => {
-        product.cachedImage = rootImageURI + 'image-one_240x360.jpg'
+        product.cachedImage = rootImageURI + 'image-one_240x360.jpg';
         assert.notOk(product.shouldUpdateImage);
       });
     });
@@ -655,6 +655,11 @@ describe('Product class', () => {
       it('returns 480x720 default image', () => {
         product.config.product.width = undefined;
         assert.equal(product.image.src, rootImageURI + 'image-one_480x720.jpg');
+      });
+
+      it('returns a srcLarge image option', () => {
+        product.config.product.width = undefined;
+        assert.equal(product.image.srcLarge, rootImageURI + 'image-one_550x825.jpg');
       });
     });
 


### PR DESCRIPTION
- Updated the `index.example.html` starter file
- Added a new key to the `image` object for `srcLarge`. We need to use this for horizontal layouts and primary images in the modal. The current `src` url image has a max height/width of 480 which is not sufficient.


`srcLarge` isn't the best name. if you've got a better suggestion that'd be sweet. also, ideally the `src` key should just have various sizes listed under it, but this will require significant change. we can perhaps focus on that at a later time.