### PR TITLE
Fix behaviour for invalid localStorage key

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "morphdom": "1.4.6",
     "mustache": "2.2.1",
     "node-sass": "3.8.0",
-    "shopify-buy": "1.0.2",
+    "shopify-buy": "1.1.0",
     "uglify-js": "2.7.0"
   }
 }

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -132,6 +132,14 @@ export default class Cart extends Component {
     }
   }
 
+  createCheckout() {
+    return this.props.client.checkout.create().then((checkout) => {
+      localStorage.setItem('checkoutId', checkout.id);
+      this.model = checkout;
+      return checkout;
+    });
+  }
+
   /**
    * get model data either by calling client.createCart or loading from localStorage.
    * @return {Promise} promise resolving to cart instance.
@@ -143,15 +151,10 @@ export default class Cart extends Component {
         this.model = checkout;
         this.updateCache(this.model.lineItems);
         return checkout;
-      });
+      }).catch(() => { return this.createCheckout(); });
     } else {
-      return this.props.client.checkout.create().then((checkout) => {
-        localStorage.setItem('checkoutId', checkout.id);
-        this.model = checkout;
-        return checkout;
-      });
+      return this.createCheckout();
     }
-    // return this.props.client.fetchRecentCart();
   }
 
   fetchMoneyFormat() {

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -132,6 +132,10 @@ export default class Cart extends Component {
     }
   }
 
+  /**
+   * creates a cart instance
+   * @return {Promise} promise resolving to cart instance
+   */
   createCheckout() {
     return this.props.client.checkout.create().then((checkout) => {
       localStorage.setItem('checkoutId', checkout.id);

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -92,12 +92,14 @@ describe('Cart class', () => {
   });
 
   describe('fetchData()', () => {
-    it('calls createCart on client if localStorage invalid', () => {
+    it('calls createCart on client if localStorage is invalid', () => {
       localStorage.setItem('checkoutId', 1);
+      const fetchCart = sinon.stub(cart.props.client.checkout, 'fetch').returns(Promise.reject({errors: [{ message: 'rejected.' }]}));
       const createCheckout = sinon.stub(cart.props.client.checkout, 'create').returns(Promise.resolve({id: 12345, lineItems: []}));
 
       return cart.fetchData().then((data) => {
         assert.deepEqual(data, {id: 12345, lineItems: []});
+        assert.calledOnce(fetchCart);
         assert.calledOnce(createCheckout);
         assert.equal(localStorage.getItem('checkoutId'), 12345);
       });

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -91,6 +91,19 @@ describe('Cart class', () => {
     });
   });
 
+  describe('fetchData()', () => {
+    it('calls createCart on client if localStorage invalid', () => {
+      localStorage.setItem('checkoutId', 1);
+      const createCheckout = sinon.stub(cart.props.client.checkout, 'create').returns(Promise.resolve({id: 12345, lineItems: []}));
+
+      return cart.fetchData().then((data) => {
+        assert.deepEqual(data, {id: 12345, lineItems: []});
+        assert.calledOnce(createCheckout);
+        assert.equal(localStorage.getItem('checkoutId'), 12345);
+      });
+    });
+  });
+
   describe('fetchMoneyFormat()', () => {
     it('calls fetchShopInfo on client', () => {
       localStorage.setItem('checkoutId', 12345)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4712,9 +4712,9 @@ shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
-shopify-buy@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.0.2.tgz#d16a1ffff3112091f59795d3c01d910b8233a1b8"
+shopify-buy@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.1.0.tgz#92685fcd7d07331637cb1b05bc28aa3b6b5d9e33"
 
 sigmund@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Bump the `shopify-buy` version and `fetchData()` to use the newly added behaviour. 
The code assumed that if `checkoutId` is defined in local storage, it's also valid. This isn't always the case and the behaviour is accounted for in this PR.