### PR TITLE
Extract storefrontId if it's in an array

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -533,7 +533,9 @@ export default class Product extends Component {
    * @return {Promise} promise resolving to model data.
    */
   sdkFetch() {
-    if (this.storefrontId) {
+    if (this.storefrontId && Array.isArray(this.storefrontId)) {
+      return this.props.client.product.fetch(this.storefrontId[0]);
+    } else if (this.storefrontId) {
       return this.props.client.product.fetch(this.storefrontId);
     } else if (this.handle) {
       return this.props.client.product.fetchByHandle(this.handle).then((product) => product);

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -374,6 +374,12 @@ describe('Product class', () => {
         idProduct.sdkFetch();
         assert.calledWith(productFetchStub, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMzQ1');
       });
+
+      it('calls fetchProduct with product storefront id if storefront id is passed in as an array', () => {
+        idProduct.storefrontId = [idProduct.storefrontId];
+        idProduct.sdkFetch();
+        assert.calledWith(productFetchStub, 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMzQ1');
+      });
     });
 
     describe('when passed a product handle', () => {


### PR DESCRIPTION
In certain scenarios we were seeing issues with the `ID` field because we were trying to fetch with `["someId"]` instead of `"someId"`. 