### PR TITLE
Fallback strategy when no variant or product image is defined

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -7,7 +7,7 @@ import formatMoney from '../utils/money';
 import CartView from '../views/cart';
 import CartUpdater from '../updaters/cart';
 
-const NO_IMG_URL = '//sdks.shopifycdn.com/buy-button/latest/no-image.jpg';
+export const NO_IMG_URL = '//sdks.shopifycdn.com/buy-button/latest/no-image.jpg';
 
 /**
  * Renders and cart embed.

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -20,6 +20,8 @@ function isMedia(key) {
   return key.charAt(0) === '@';
 }
 
+const NO_IMG_URL = 'https://sdks.shopifycdn.com/buy-button/latest/no-image.jpg';
+
 const ENTER_KEY = 13;
 
 const propertiesWhitelist = [
@@ -141,6 +143,14 @@ export default class Product extends Component {
       id = this.selectedImage.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptionsLarge);
+    } else if (this.selectedVariant.image == null && this.model.images[0] == null) {
+      id = null;
+      src = NO_IMG_URL;
+      srcLarge = NO_IMG_URL;
+    } else if (this.selectedVariant.image == null) {
+      id = this.model.images[0].id;
+      src = this.model.images[0].src;
+      srcLarge = this.props.client.image.helpers.imageForSize(this.model.images[0], imageOptionsLarge);
     } else {
       id = this.selectedVariant.image.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptions);

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -7,6 +7,7 @@ import formatMoney from '../utils/money';
 import normalizeConfig from '../utils/normalize-config';
 import ProductView from '../views/product';
 import ProductUpdater from '../updaters/product';
+import {NO_IMG_URL as noImageUrl} from './cart';
 
 function isFunction(obj) {
   return Boolean(obj && obj.constructor && obj.call && obj.apply);
@@ -19,8 +20,6 @@ function isPseudoSelector(key) {
 function isMedia(key) {
   return key.charAt(0) === '@';
 }
-
-const NO_IMG_URL = 'https://sdks.shopifycdn.com/buy-button/latest/no-image.jpg';
 
 const ENTER_KEY = 13;
 
@@ -145,8 +144,8 @@ export default class Product extends Component {
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptionsLarge);
     } else if (this.selectedVariant.image == null && this.model.images[0] == null) {
       id = null;
-      src = NO_IMG_URL;
-      srcLarge = NO_IMG_URL;
+      src = noImageUrl;
+      srcLarge = noImageUrl;
     } else if (this.selectedVariant.image == null) {
       id = this.model.images[0].id;
       src = this.model.images[0].src;

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -10,6 +10,7 @@ import shopFixture from '../fixtures/shop-info';
 import productFixture from '../fixtures/product-fixture';
 
 const rootImageURI = 'https://cdn.shopify.com/s/';
+const NO_IMG_URL = 'https://sdks.shopifycdn.com/buy-button/latest/no-image.jpg';
 
 const config = {
   id: 123,
@@ -666,6 +667,26 @@ describe('Product class', () => {
       it('returns a srcLarge image option', () => {
         product.config.product.width = undefined;
         assert.equal(product.image.srcLarge, rootImageURI + 'image-one_550x825.jpg');
+      });
+    });
+
+    describe('if selected variant doesn\'t have an image', () => {
+      beforeEach(() => {
+        testProductCopy.variants[0].image = null;
+        return product.init(testProductCopy).then(() => {
+          product.selectedImage = null;
+          product.defaultStorefrontVariantId = 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0Nw==';
+          return Promise.resolve();
+        });
+      });
+
+      it('returns the default product image', () => {
+        assert.equal(product.image.src, rootImageURI + 'image-one.jpg');
+      });
+
+      it('returns the NO_IMG_URL product image', () => {
+        product.model.images = [];
+        assert.equal(product.image.src, NO_IMG_URL);
       });
     });
 

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -1,5 +1,5 @@
 import Product from '../../src/components/product';
-import Cart from '../../src/components/cart';
+import Cart, { NO_IMG_URL as noImageUrl } from '../../src/components/cart';
 import Modal from '../../src/components/modal';
 import Template from '../../src/template';
 import Component from '../../src/component';
@@ -10,7 +10,6 @@ import shopFixture from '../fixtures/shop-info';
 import productFixture from '../fixtures/product-fixture';
 
 const rootImageURI = 'https://cdn.shopify.com/s/';
-const NO_IMG_URL = 'https://sdks.shopifycdn.com/buy-button/latest/no-image.jpg';
 
 const config = {
   id: 123,
@@ -686,7 +685,7 @@ describe('Product class', () => {
 
       it('returns the NO_IMG_URL product image', () => {
         product.model.images = [];
-        assert.equal(product.image.src, NO_IMG_URL);
+        assert.equal(product.image.src, noImageUrl);
       });
     });
 


### PR DESCRIPTION
Latest storefront failure was due to `selectedVariant.image` being undefined. This PR should address the issue by using the `NO_IMG_URL` form cdn, or the first product image, if it exists