### PR TITLE
Fix describe options to only ever select 1 option

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -396,7 +396,7 @@ export default class Product extends Component {
         values: option.values.map((value) => {
           return {
             name: value.value,
-            selected: Object.values(this.selectedOptions).some((selectedOption) => {
+            selected: Object.values([this.selectedOptions[option.name]]).some((selectedOption) => {
               return selectedOption === value.value;
             }),
           };

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -396,9 +396,7 @@ export default class Product extends Component {
         values: option.values.map((value) => {
           return {
             name: value.value,
-            selected: Object.values([this.selectedOptions[option.name]]).some((selectedOption) => {
-              return selectedOption === value.value;
-            }),
+            selected: this.selectedOptions[option.name] === value.value,
           };
         }),
       };

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -295,6 +295,20 @@ describe('Product class', () => {
         assert.deepEqual(product.decoratedOptions, expectedArray);
       });
     });
+
+    it('it does not return options with multiple selected values in the same option name', () => {
+      expectedArray[0].values.push({name: 'something', selected: true});
+      expectedArray[0].values[0].selected = false;
+      expectedArray[1].values.push({name: 'something', selected: false});
+
+      return product.init(testProductCopy).then(() => {
+        product.model.options[0].values.push({value: 'something'});
+        product.model.options[1].values.push({value: 'something'});
+
+        product.updateVariant('Print', 'something');
+        assert.deepEqual(product.decoratedOptions, expectedArray);
+      });
+    });
   });
 
   describe('get viewData', () => {


### PR DESCRIPTION
`describeOptions` would sometimes select multiple options if we have duplicated values in different dropdown lists. This PR should fix it