### PR TITLE
Revert "Use default product image in thumbnail if defined"

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -127,8 +127,6 @@ export default class Cart extends Component {
     };
     if (lineItem.variant.image) {
       return this.props.client.image.helpers.imageForSize(lineItem.variant.image, imageOptions);
-    } else if (lineItem.variant.product.images[0]) {
-      return this.props.client.image.helpers.imageForSize(lineItem.variant.product.images[0], imageOptions);
     } else {
       return NO_IMG_URL;
     }


### PR DESCRIPTION
JS errors are preventing a lot of shops from adding products to carts.

Reverts Shopify/buy-button-js#450