### PR TITLE
fixed issue with the selector when there are multiple class names

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -198,7 +198,7 @@ export default class ProductSet extends Component {
       return Promise.resolve();
     }
     const productConfig = Object.assign({}, this.globalConfig, {
-      node: this.view.document.querySelector(`.${this.classes.productSet.products}`),
+      node: this.view.document.querySelector(`.${this.classes.productSet.products.replace(/\s+/g, '.')}`),
       options: merge({}, this.config, {
         product: {
           iframe: false,


### PR DESCRIPTION
Fixed issue with the selector when there are multiple class names by replacing space with period.

E.g. if I set `products` class in 'productSet' to multiple class names, something like this:
```json
productSet: {
    iframe: false,
    contents: {
        pagination: true,
    },
    classes: {
        products: "shopify-buy__collection-products row",
    }
}
```

this will break the query selector, something like this:

```js
node: this.view.document.querySelector('.shopify-buy__collection-products row')
```

This fix will replace space with `.` (example below), so the selector works even with multiple class names.
```js
node: this.view.document.querySelector('.shopify-buy__collection-products.row')
```