### PR TITLE
Handle invalid variantId

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -744,16 +744,14 @@ export default class Product extends Component {
       this.selectedImage = model.images[0];
     }
 
-    if (selectedVariant) {
-      this.selectedOptions = selectedVariant.selectedOptions.reduce((acc, option) => {
-        acc[option.name] = option.value;
-        return acc;
-      }, {});
-      this.selectedVariant = selectedVariant;
-    } else {
-      // eslint-disable-next-line
-      console.error('invalid variant ID');
+    if (!selectedVariant) {
+      selectedVariant = model.variants[0];
     }
+    this.selectedOptions = selectedVariant.selectedOptions.reduce((acc, option) => {
+      acc[option.name] = option.value;
+      return acc;
+    }, {});
+    this.selectedVariant = selectedVariant;
     return model;
   }
 }

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -505,6 +505,13 @@ describe('Product class', () => {
       assert.equal(product.selectedOptions.Print, 'shark');
       assert.equal(product.selectedOptions.Size, 'large');
     });
+
+    it('falls back to first variantId if invalid variantId was provided', () => {
+      product.defaultStorefrontVariantId = 'this is an invalid variant id';
+      const model = product.setDefaultVariant(testProduct);
+      assert.equal(product.selectedOptions.Print, 'sloth');
+      assert.equal(product.selectedOptions.Size, 'small');
+    });
   });
 
   describe('get buttonText', () => {


### PR DESCRIPTION
When we're pulling an invalid variant, buy buttons would stop working and show `unavailable` text instead. This PR will add a fallback method for handling those cases and default to the first variant if the selected `variantId` was invalid.