### PR TITLE
Make the checkout local storage key unique per shopify buy client

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "morphdom": "1.4.6",
     "mustache": "2.2.1",
     "node-sass": "3.8.0",
-    "shopify-buy": "1.3.1",
+    "shopify-buy": "1.4.0",
     "uglify-js": "2.7.0"
   }
 }

--- a/src/buybutton.js
+++ b/src/buybutton.js
@@ -15,13 +15,13 @@ ShopifyBuy.UI = window.ShopifyBuy.UI || {
   domains: {},
 
   init(client, integrations = {}, styleOverrides) {
-    const domain = client.shop.fetchInfo().then((res) => {
-      return res.attrs.primaryDomain.attrs.host.value;
-    });
-    if (!this.domains[domain]) {
-      this.domains[domain] = new UI(client, integrations, styleOverrides);
+    const uniqueClientKey = `${client.config.domain}.${client.config.storefrontAccessToken}`;
+
+    if (!this.domains[uniqueClientKey]) {
+      this.domains[uniqueClientKey] = new UI(client, integrations, styleOverrides);
     }
-    return this.domains[domain];
+
+    return this.domains[uniqueClientKey];
   },
 
   adapterHelpers: {

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -119,6 +119,10 @@ export default class Cart extends Component {
     return this.isVisible ? 'is-active' : '';
   }
 
+  get localStorageCheckoutKey() {
+    return `${this.props.client.config.storefrontAccessToken}.${this.props.client.config.domain}.checkoutId`;
+  }
+
   imageForLineItem(lineItem) {
     const imageSize = 180;
     const imageOptions = {
@@ -138,7 +142,8 @@ export default class Cart extends Component {
    */
   createCheckout() {
     return this.props.client.checkout.create().then((checkout) => {
-      localStorage.setItem('checkoutId', checkout.id);
+
+      localStorage.setItem(this.localStorageCheckoutKey, checkout.id);
       this.model = checkout;
       return checkout;
     });
@@ -149,7 +154,7 @@ export default class Cart extends Component {
    * @return {Promise} promise resolving to cart instance.
    */
   fetchData() {
-    const checkoutId = localStorage.getItem('checkoutId');
+    const checkoutId = localStorage.getItem(this.localStorageCheckoutKey);
     if (checkoutId) {
       return this.props.client.checkout.fetch(checkoutId).then((checkout) => {
         this.model = checkout;

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -109,7 +109,7 @@ describe('Cart class', () => {
 
   describe('fetchData()', () => {
     it('calls fetchRecentCart on client', () => {
-      localStorage.setItem('checkoutId', 12345)
+      localStorage.setItem(cart.localStorageCheckoutKey, 12345)
       const fetchCart = sinon.stub(cart.props.client.checkout, 'fetch').returns(Promise.resolve({id: 12345, lineItems: []}));
 
       return cart.fetchData().then((data) => {
@@ -120,7 +120,7 @@ describe('Cart class', () => {
     });
 
     it('calls createCart on client if localStorage is invalid', () => {
-      localStorage.setItem('checkoutId', 1);
+      localStorage.setItem(cart.localStorageCheckoutKey, 1);
       const fetchCart = sinon.stub(cart.props.client.checkout, 'fetch').returns(Promise.reject({errors: [{ message: 'rejected.' }]}));
       const createCheckout = sinon.stub(cart.props.client.checkout, 'create').returns(Promise.resolve({id: 12345, lineItems: []}));
 
@@ -128,13 +128,13 @@ describe('Cart class', () => {
         assert.deepEqual(data, {id: 12345, lineItems: []});
         assert.calledOnce(fetchCart);
         assert.calledOnce(createCheckout);
-        assert.equal(localStorage.getItem('checkoutId'), 12345);
+        assert.equal(localStorage.getItem(cart.localStorageCheckoutKey), 12345);
       });
     });
 
     it('calls createCart on client if checkout is completed', () => {
       const checkout = {id: 1111, lineItems: []};
-      localStorage.setItem('checkoutId', 123);
+      localStorage.setItem(cart.localStorageCheckoutKey, 123);
       const fetchCart = sinon.stub(cart.props.client.checkout, 'fetch').returns(Promise.resolve({ completedAt: "04-12-2018", lineItems: []}));
       const createCheckout = sinon.stub(cart.props.client.checkout, 'create').returns(Promise.resolve(checkout));
 
@@ -142,14 +142,14 @@ describe('Cart class', () => {
         assert.deepEqual(data, checkout);
         assert.calledOnce(fetchCart);
         assert.calledOnce(createCheckout);
-        assert.equal(localStorage.getItem('checkoutId'), checkout.id);
+        assert.equal(localStorage.getItem(cart.localStorageCheckoutKey), checkout.id);
       });
     });
   });
 
   describe('fetchMoneyFormat()', () => {
     it('calls fetchShopInfo on client', () => {
-      localStorage.setItem('checkoutId', 12345)
+      localStorage.setItem(cart.localStorageCheckoutKey, 12345)
       const fetchMoneyFormat = sinon.stub(cart.props.client.shop, 'fetchInfo').returns(Promise.resolve({ moneyFormat: '₿{{amount}}'}));
 
       return cart.fetchMoneyFormat().then((data) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4753,9 +4753,9 @@ shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
-shopify-buy@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.3.1.tgz#37e45989cc77f5cfa7a99fdb951fcd8c4a65574e"
+shopify-buy@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.4.0.tgz#e51a66c4c6340a79c1198609e1b3e82e501e53a6"
 
 sigmund@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This stops pages with multiple embeds from different shops and different
channels from clobbering each others cart IDs