### PR TITLE
[RFC] update carousel index on every carousel change

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -80,6 +80,7 @@ export default class Product extends Component {
     this.selectedVariant = {};
     this.selectedOptions = {};
     this.selectedImage = null;
+    this.carouselIndex = 1;
     this.updater = new ProductUpdater(this);
     this.view = new ProductView(this);
   }
@@ -202,7 +203,7 @@ export default class Product extends Component {
       priceClass: this.priceClass,
       formattedPrice: this.formattedPrice,
       formattedCompareAtPrice: this.formattedCompareAtPrice,
-      carouselIndex: 0,
+      carouselIndex: this.carouselIndex,
       carouselImages: this.carouselImages,
     });
   }
@@ -659,8 +660,10 @@ export default class Product extends Component {
       return image.id === this.currentImage.id;
     })[0];
     const currentImageIndex = imageList.indexOf(currentImage);
-    this.selectedImage = imageList[this.nextIndex(currentImageIndex, offset)];
+    const nextImageIndex = this.nextIndex(currentImageIndex, offset);
+    this.selectedImage = imageList[nextImageIndex];
     this.cachedImage = this.selectedImage;
+    this.carouselIndex = (nextImageIndex + 1)
     this.view.render();
   }
 


### PR DESCRIPTION
Hi there,

today we tried to implement a carousel pagination (i.e. 1 image of 3 images) in a product component. We tried several workarounds but nothing worked as expected. We found the carouselIndex property on the corresponding view that was set once to 0, but never got updated. This PR fixes this and makes our use case as simply as editing the `imgWithCarousel` template and adding the variables `{{data.carouselIndex}}` and `{{data.carouselImages.length}}`.

Feel free to comment :)

Cheerio