### PR TITLE
Empty cart when direct checkout button is clicked

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -592,9 +592,11 @@ export default class Product extends Component {
         checkoutWindow = window;
       }
 
-      this.cart.addVariantToCart(this.selectedVariant, this.selectedQuantity, false).then((cart) => {
-        this.cart.close();
-        checkoutWindow.location = cart.webUrl;
+      this.cart.empty().then(() => {
+        this.cart.addVariantToCart(this.selectedVariant, this.selectedQuantity, false).then((cart) => {
+          this.cart.close();
+          checkoutWindow.location = cart.webUrl;
+        });
       });
     }
   }

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -802,5 +802,31 @@ describe('Product class', () => {
         title: "sloth / small"
       }, 1111);
     });
+
+    it('empty cart and add variant to cart are called when destination is checkout', async () => {
+      product.config.product.buttonDestination = 'checkout';
+      product.config.cart.popup = true;
+      sinon.stub(product.cart, 'close');
+      sinon.stub(window, 'open').returns({location: ''});
+      
+      const emptyCart = sinon.stub(product.cart, 'empty').returns(Promise.resolve());
+      const addToCart = sinon.stub(product.cart, 'addVariantToCart').returns(Promise.resolve({webUrl: 'test'}));
+      const evt = new Event('click shopify-buy__btn--parent');
+      const target = 'shopify-buy__btn--parent';
+
+      await product.onButtonClick(evt, target);
+
+      assert.calledOnce(emptyCart);
+      assert.calledOnce(addToCart);
+      assert.calledWith(addToCart, {
+        available: true,
+        id: "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==",
+        image: null,
+        price: "123.00",
+        productId: 123,
+        selectedOptions: [{ name: "Print", value: "sloth" }, { name: "Size", value: "small" }],
+        title: "sloth / small"
+      }, 1, false);
+    });
   });
 });


### PR DESCRIPTION
#### What are you trying to accomplish with this PR?
Currently, the direct checkout button adds an item to the cart, but does not clear the cart before doing so. This can lead to buyers proceeding with a checkout that contains multiple items, contrary to what is found in the help docs: `Direct checkout brings the customer to a checkout page, where they can purchase the product. If a customer chooses this option, then they aren't able to add additional products to their order.`

![old-cart](https://user-images.githubusercontent.com/12417232/43419983-8952b062-9410-11e8-9b2a-1c9ede92cdfa.gif)

Ideally, clicking the direct checkout button should always lead to a cart which only contains the variant selected. 

#### How does it do it?
The cart gets emptied before adding the specific variant to the cart. 

![new-cart](https://user-images.githubusercontent.com/12417232/43421224-1c29ed8a-9414-11e8-932d-21a96a5e234e.gif)

It should be noted that this does not resolve the issue of the cart toggle appearing when the button is clicked. This only addresses the problem of a direct checkout button resulting in a multi-item cart. 

I also considered running `atob` on `this.selectedVariant.id` to decode the guid, and use its known structure to extract the variant id. This could then be used to build a cart permalink, which would be injected directly into the checkout window. This approach would also solve the issue of the cart toggle appearing, however I feel that it's cleaner to go through the js-buy-sdk. 