### PR TITLE
Create a new checkout to manage direct checkouts

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -592,9 +592,11 @@ export default class Product extends Component {
         checkoutWindow = window;
       }
 
-      this.cart.addVariantToCart(this.selectedVariant, this.selectedQuantity, false).then((cart) => {
-        this.cart.close();
-        checkoutWindow.location = cart.webUrl;
+      this.props.client.checkout.create().then((checkout) => {
+        const lineItem = {variantId: this.selectedVariant.id, quantity: 1};
+        this.props.client.checkout.addLineItems(checkout.id, [lineItem]).then((updatedCheckout) => {
+          checkoutWindow.location = updatedCheckout.webUrl;
+        });
       });
     }
   }


### PR DESCRIPTION
#### What are you trying to accomplish with the PR?
This relates to #489 but offers a different approach to resolving the multi-item checkout problem. After discussing the behaviour with UX, it was decided that clicking the direct checkout button should not result in the cart toggle appearing. From a buyer's perspective, direct checkout buttons should not be associated to building a cart. Additionally, if multiple buy buttons are embedded on a page, the direct checkout buttons should not interfere with any cart which may exist for the other buttons. 

Note: This change would make it impossible for a product available via a direct checkout button to be purchased in a multi-item cart. 

#### How does it do it?
- A new checkout is created when the direct checkout button is clicked, and the variant is added to that cart. 
- The webUrl for that cart is used for the checkout window

Old Behaviour:
![old-direct-checkout](https://user-images.githubusercontent.com/12417232/43540890-ee203f0a-9596-11e8-884b-f750097355a5.gif)


New Behaviour:
![new-direct-checkout](https://user-images.githubusercontent.com/12417232/43540898-f2340612-9596-11e8-99aa-bf0fd65acb59.gif)
