### PR TITLE
Add more tracking for the product component

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -412,7 +412,7 @@ export default class Product extends Component {
     };
 
     if (this.selectedVariant) {
-      return Object.assign({}, info, {
+      Object.assign(info, {
         id: this.id,
         name: this.selectedVariant.productTitle,
         sku: null,

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -413,9 +413,12 @@ export default class Product extends Component {
         name: this.selectedVariant.productTitle,
         sku: null,
         price: this.selectedVariant.price,
+        destination: this.options.buttonDestination,
       };
     } else {
-      return {};
+      return {
+        destination: this.options.buttonDestination,
+      };
     }
   }
 
@@ -583,6 +586,7 @@ export default class Product extends Component {
       this.openOnlineStore();
     } else {
       this._userEvent('openCheckout');
+      this.props.tracker.track('Direct Checkout', {});
       let checkoutWindow;
 
       if (this.config.cart.popup) {

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -407,19 +407,20 @@ export default class Product extends Component {
    * @return {Object}
    */
   get trackingInfo() {
+    const info = {
+      destination: this.options.buttonDestination,
+    };
+
     if (this.selectedVariant) {
-      return {
+      return Object.assign({}, info, {
         id: this.id,
         name: this.selectedVariant.productTitle,
         sku: null,
         price: this.selectedVariant.price,
-        destination: this.options.buttonDestination,
-      };
-    } else {
-      return {
-        destination: this.options.buttonDestination,
-      };
+      });
     }
+
+    return info;
   }
 
   /**

--- a/src/ui.js
+++ b/src/ui.js
@@ -85,6 +85,7 @@ export default class UI {
         this.tracker.trackComponent('product', product);
       });
     } else {
+      debugger;
       this.tracker.trackComponent(type, component.trackingInfo);
     }
   }

--- a/src/ui.js
+++ b/src/ui.js
@@ -85,7 +85,6 @@ export default class UI {
         this.tracker.trackComponent('product', product);
       });
     } else {
-      debugger;
       this.tracker.trackComponent(type, component.trackingInfo);
     }
   }

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -50,7 +50,10 @@ describe('Product class', () => {
           return function () {
             fn(...arguments);
           }
-        }
+        },
+        track: (eventName, properties) => {
+          return;
+        },
       },
       createCart: function () {
         return Promise.resolve(new Cart(config, {

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -51,9 +51,7 @@ describe('Product class', () => {
             fn(...arguments);
           }
         },
-        track: (eventName, properties) => {
-          return;
-        },
+        track: sinon.stub(),
       },
       createCart: function () {
         return Promise.resolve(new Cart(config, {
@@ -846,6 +844,8 @@ describe('Product class', () => {
       });
 
       product.onButtonClick(evt, target);
+
+      assert.calledWith(product.props.tracker.track, 'Direct Checkout', {})
     });
   });
 });


### PR DESCRIPTION
## What are you trying to accomplish with this PR?
Looking to add a bit more attributes to the current tracking to be able to calculate click-rate

For this we need to have amounts of click + amounts of views per destination


## How is this accomplished?
- Add visibility around the `buttonDestination` attribute
- Track the event of direct checkout being clicked

With a custom tracker that logs the events, I was able to test locally
![image](https://user-images.githubusercontent.com/5460957/44167970-a5657700-a09d-11e8-92da-27c95345b9e5.png)
