### PR TITLE
Fix direct checkout quantity

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -593,7 +593,7 @@ export default class Product extends Component {
       }
 
       this.props.client.checkout.create().then((checkout) => {
-        const lineItem = {variantId: this.selectedVariant.id, quantity: 1};
+        const lineItem = {variantId: this.selectedVariant.id, quantity: this.selectedQuantity};
         this.props.client.checkout.addLineItems(checkout.id, [lineItem]).then((updatedCheckout) => {
           checkoutWindow.location = updatedCheckout.webUrl;
         });

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -804,7 +804,9 @@ describe('Product class', () => {
     });
 
     it('create checkout and add line items are called when destination is checkout', () => {
+      const selectedQuantity = 2;
       product.config.product.buttonDestination = 'checkout';
+      product.selectedQuantity = selectedQuantity;
 
       const openWindow = sinon.stub(window, 'open').returns({location: ''});
       const checkoutMock = {id: 1, webUrl: ''};
@@ -834,7 +836,7 @@ describe('Product class', () => {
         assert.calledOnce(addLineItems);
         assert.calledWith(addLineItems, checkoutMock.id, [{
           variantId: "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==",
-          quantity: 1,
+          quantity: selectedQuantity,
         }]);
 
         openWindow.restore();


### PR DESCRIPTION
In #490, the direct checkout behaviour was updated to create a new cart for checkout, and add the selected variant to it. However, a quantity of 1 was always being added, regardless of the quantity input. 
This PR adds the expected quantity to the cart. 

Before:
![bad-buy-now](https://user-images.githubusercontent.com/12417232/44221051-50356e00-a14e-11e8-86e2-e30a9ac90535.gif)


After:
![good-buy-now](https://user-images.githubusercontent.com/12417232/44221072-59bed600-a14e-11e8-9174-ed59b60afaa2.gif)

