### PR TITLE
Use the globalConfig's moneyFormat for the cart

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -182,7 +182,7 @@ export default class Cart extends Component {
    * @return {Promise} promise resolving to instance.
    */
   init(data) {
-    if (!this.config.moneyFormat) {
+    if (!this.moneyFormat) {
       this.fetchMoneyFormat().then((moneyFormat) => {
         this.moneyFormat = moneyFormat;
       });

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -28,7 +28,8 @@ describe('Cart class', () => {
             fn(...arguments);
           }
         }
-      }
+      },
+      fetchMoneyFormat: function () { return Promise.resolve('test') }
     });
   });
   afterEach(() => {
@@ -242,6 +243,28 @@ describe('Cart class', () => {
         assert.calledOnce(removeLineItemsStub);
         assert.calledOnce(cart.view.render);
         assert.calledOnce(cart.toggles[0].view.render);
+      });
+    });
+  });
+
+  describe('init', () => {
+    it('calls fetchMoneyFormat when moneyFormat has not been set', () => {
+      cart.moneyFormat = null;
+      const fetchMoneyFormatStub = sinon.stub(cart.props, 'fetchMoneyFormat').returns(Promise.resolve());
+
+      cart.init().then(() => {
+        assert.calledOnce(fetchMoneyFormatStub);
+        fetchMoneyFormatStub.restore();
+      });
+    });
+
+    it('does not call fetchMoneyFormat when moneyFormat has been set', () => {
+      cart.moneyFormat = '₿{{amount}}';
+      const fetchMoneyFormatStub = sinon.stub(cart.props, 'fetchMoneyFormat').returns(Promise.resolve());
+
+      cart.init().then(() => {
+        assert.notCalled(fetchMoneyFormatStub);
+        fetchMoneyFormatStub.restore();
       });
     });
   });


### PR DESCRIPTION
The `moneyFormat` passed in via `createComponent` is available on the `globalConfig` not on `config`, which is causing the cart's money format to always be fetched from the js-buy-sdk. 
To determine whether we need to be fetching it from the sdk, we should be checking `this.moneyFormat`, which is being set in the constructor based off of the `globalConfig` value.  

