### PR TITLE
Re-add html escaping to cart total and line-item prices

### DIFF
--- a/src/templates/cart.js
+++ b/src/templates/cart.js
@@ -12,8 +12,8 @@ const cartTemplates = {
               </div>`,
   footer: `{{^data.isEmpty}}
             <div class="{{data.classes.cart.footer}}" data-element="cart.footer">
-              <p class="{{data.classes.cart.subtotalText}}" data-element="cart.total">{{{data.text.total}}}</p>
-              <p class="{{data.classes.cart.subtotal}}" data-element="cart.subtotal">{{{data.formattedTotal}}}</p>
+              <p class="{{data.classes.cart.subtotalText}}" data-element="cart.total">{{data.text.total}}</p>
+              <p class="{{data.classes.cart.subtotal}}" data-element="cart.subtotal">{{data.formattedTotal}}</p>
               <p class="{{data.classes.cart.notice}}" data-element="cart.notice">{{data.text.notice}}</p>
               <button class="{{data.classes.cart.button}}" type="button" data-element="cart.button">{{data.text.button}}</button>
             </div>

--- a/src/templates/line-item.js
+++ b/src/templates/line-item.js
@@ -3,7 +3,7 @@ const lineItemTemplates = {
   variantTitle: '<div class="{{data.classes.lineItem.variantTitle}}" data-element="lineItem.variantTitle">{{data.variantTitle}}</div>',
 
   title: '<span class="{{data.classes.lineItem.itemTitle}}" data-element="lineItem.itemTitle">{{data.title}}</span>',
-  price: '<span class="{{data.classes.lineItem.price}}" data-element="lineItem.price">{{{data.formattedPrice}}}</span>',
+  price: '<span class="{{data.classes.lineItem.price}}" data-element="lineItem.price">{{data.formattedPrice}}</span>',
   quantity: `<div class="{{data.classes.lineItem.quantity}}" data-element="lineItem.quantity">
               <button class="{{data.classes.lineItem.quantityButton}} {{data.classes.lineItem.quantityDecrement}}" type="button" data-line-item-id="{{data.id}}" data-element="lineItem.quantityDecrement">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M4 7h8v2H4z"/></svg><span class="visuallyhidden">Decrement</span>


### PR DESCRIPTION
In this PR, HTML escaping will be re-added to the `pricing` values within `cart` and `line-item` templates. This fixes [#2455](https://github.com/Shopify/buy-button/issues/2455).