### PR TITLE
Add custom outerHeight() to Product component to always return clientHeight

### DIFF
--- a/src/views/product.js
+++ b/src/views/product.js
@@ -13,6 +13,10 @@ export default class ProductView extends View {
     return true;
   }
 
+  get outerHeight() {
+    return `${this.wrapper.clientHeight}px`;
+  }
+
   /**
    * add event listener which triggers resize when the product image is loaded.
    */

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -850,4 +850,19 @@ describe('Product class', () => {
       assert.calledWith(product.props.tracker.track, 'Direct Checkout', {})
     });
   });
+
+  describe('get view.outerHeight', () => {
+    beforeEach(() => {
+      return product.init(testProductCopy).then((product) => {
+        product.cart.model.lineItems = [];
+        product.cart.props.client = product.props.client;
+        return Promise.resolve();
+      });
+    });
+
+    it('returns the wrapper\'s client height in px', () => {
+      const wrapperHeight = product.view.wrapper.clientHeight;
+      assert.equal(product.view.outerHeight, `${wrapperHeight}px`);
+    });
+  });
 });

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -244,8 +244,13 @@ describe('View class', () => {
         id: 1234,
       }, {browserFeatures: {}});
       view = new View(component);
-      resizeX = sinon.stub(view, '_resizeX');
-      resizeY = sinon.stub(view, '_resizeY');
+      resizeX = sinon.spy(view, '_resizeX');
+      resizeY = sinon.spy(view, '_resizeY');
+    });
+
+    afterEach(() => {
+      resizeX.restore();
+      resizeY.restore();
     });
 
     it('does nothing if no iframe or no wrapper', () => {
@@ -257,6 +262,49 @@ describe('View class', () => {
       view.wrapper = null;
       assert.notCalled(resizeX);
       assert.notCalled(resizeY);
+    });
+
+    it('resizes iframe width when shouldResizeX is true', () => {
+      const iframe = document.createElement('iframe');
+      const iframeWidth = 100;
+      view = Object.defineProperty(view, 'shouldResizeX', {
+        value: true,
+        writable: false,
+      });
+      view.wrapper = document.createElement('div');
+      view.iframe = {
+        el: iframe,
+        document: {
+          body: {
+            clientWidth: iframeWidth,
+          },
+        },
+      };
+      view.resize();
+      assert.called(resizeX);
+      assert.notCalled(resizeY);
+      assert.equal(iframe.style.width, `${iframeWidth}px`);
+    });
+
+    it('resizes iframe height when shouldResizeY is true', () => {
+      const iframe = document.createElement('iframe');
+      const iframeHeight = '50px';
+      view = Object.defineProperty(view, 'shouldResizeY', {
+        value: true,
+        writable: false,
+      });
+      view = Object.defineProperty(view, 'outerHeight', {
+        value: iframeHeight,
+        writable: false,
+      });
+      view.wrapper = document.createElement('div');
+      view.iframe = {
+        el: iframe,
+      };
+      view.resize();
+      assert.called(resizeY);
+      assert.notCalled(resizeX);
+      assert.equal(iframe.style.height, iframeHeight);
     });
   });
 


### PR DESCRIPTION
This PR updates the `product` component to always return the `clientHeight` as the outer height of the product container.  This outer height is used to set the height of the `iFrame` container.

Fixes: [#2497](https://github.com/Shopify/buy-button/issues/2497), [#2452](https://github.com/Shopify/buy-button/issues/2452), [#2366](https://github.com/Shopify/buy-button/issues/2366)