### PR TITLE
Open popup window with an empty url to prevent flashing a 404 page

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -592,7 +592,7 @@ export default class Product extends Component {
 
       if (this.config.cart.popup) {
         const params = (new Checkout(this.config)).params;
-        checkoutWindow = window.open(null, 'checkout', params);
+        checkoutWindow = window.open('', 'checkout', params);
       } else {
         checkoutWindow = window;
       }

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -1,4 +1,5 @@
 import Product from '../../src/components/product';
+import Checkout from '../../src/components/checkout';
 import Cart, { NO_IMG_URL as noImageUrl } from '../../src/components/cart';
 import Modal from '../../src/components/modal';
 import Template from '../../src/template';
@@ -828,12 +829,17 @@ describe('Product class', () => {
         });
       });
 
+      const checkout = new Checkout(product.config);
+
       const evt = new Event('click shopify-buy__btn--parent');
       const target = 'shopify-buy__btn--parent';
 
       Promise.all([createCheckoutPromise, addLineItemsPromise]).then(() => {
         assert.calledOnce(openWindow);
+        assert.calledWith(openWindow, '', 'checkout', checkout.params);
+        
         assert.calledOnce(createCheckout);
+        
         assert.calledOnce(addLineItems);
         assert.calledWith(addLineItems, checkoutMock.id, [{
           variantId: "Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==",


### PR DESCRIPTION
Fixes #501 using the solution proposed in that issue. This is also the method of opening a blank popup window proposed in the MDN docs (https://developer.mozilla.org/en-US/docs/Web/API/Window/open).  The existing implementation of passing in `null` failed because some browsers stringify a null DOMString, causing `'null'` to be appended onto the parent window's url (https://developer.mozilla.org/en-US/docs/Web/API/DOMString). 

Tested on the following browsers, to verify that an `about:blank` page appears before redirecting to the checkout: 
- MacOS: Chrome, Safari, Firefox, Opera
- iOS: Safari, Chrome, Firefox
- Windows VM: Edge, IE11, Firefox, Chrome