### PR TITLE
Expose originalSrc on product.image

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -126,6 +126,7 @@ export default class Product extends Component {
     let id;
     let src;
     let srcLarge;
+    let srcOriginal;
 
     const imageOptions = {
       maxWidth: imageSize,
@@ -141,20 +142,24 @@ export default class Product extends Component {
       id = this.selectedImage.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptionsLarge);
+      srcOriginal = this.selectedImage.src;
     } else if (this.selectedVariant.image == null && this.model.images[0] == null) {
       id = null;
       src = '';
       srcLarge = '';
+      srcOriginal = '';
     } else if (this.selectedVariant.image == null) {
       id = this.model.images[0].id;
       src = this.model.images[0].src;
       srcLarge = this.props.client.image.helpers.imageForSize(this.model.images[0], imageOptionsLarge);
+      srcOriginal = this.model.images[0].src;
     } else {
       id = this.selectedVariant.image.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptionsLarge);
+      srcOriginal = this.selectedVariant.image.src;
     }
-    return {id, src, srcLarge};
+    return {id, src, srcLarge, srcOriginal};
   }
 
   /**

--- a/test/unit/product.js
+++ b/test/unit/product.js
@@ -707,6 +707,11 @@ describe('Product class', () => {
         product.config.product.width = undefined;
         assert.equal(product.image.srcLarge, rootImageURI + 'image-one_550x825.jpg');
       });
+
+      it('returns a srcOriginal image option', () => {
+        product.config.product.width = undefined;
+        assert.equal(product.image.srcOriginal, rootImageURI + 'image-one.jpg');
+      });
     });
 
     describe('if selected variant doesn\'t have an image', () => {
@@ -727,6 +732,8 @@ describe('Product class', () => {
         it('returns no image', () => {
           product.model.images = [];
           assert.equal(product.image.src, '');
+          assert.equal(product.image.srcLarge, '');
+          assert.equal(product.image.srcOriginal, '');
         });
       });
     });
@@ -738,6 +745,9 @@ describe('Product class', () => {
       });
       it('returns smallest image larger than explicit width', () => {
         assert.equal(product.image.src, rootImageURI + 'image-one_160x240.jpg');
+      });
+      it('returns the original image source', () => {
+        assert.equal(product.image.srcOriginal, rootImageURI + 'image-one.jpg')
       });
     });
 
@@ -755,6 +765,10 @@ describe('Product class', () => {
         product.config.product.width = '480px';
         assert.equal(product.image.src, rootImageURI + 'image-three_480x720.jpg');
       })
+      it('returns the original image source when width is set explicitly', () => {
+        product.config.product.width = '480px';
+        assert.equal(product.image.srcOriginal, rootImageURI + 'image-three.jpg')
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/Shopify/buy-button-js/issues/370.

This exposes the original, un-transformed image source URL on the product resource that clients can use to display high-resolution images on their Buy Buttons.