### PR TITLE
Update product component prototype methods pt3

### DIFF
--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -319,8 +319,14 @@ describe('Product Component class', () => {
       let data;
 
       beforeEach(() => {
-        data = {};
-        modelMock = {};
+        data = {
+          id: '1',
+          title: 'hat',
+        };
+        modelMock = {
+          id: '2',
+          title: 'top',
+        };
         superSetupModelStub = sinon.stub(Component.prototype, 'setupModel').resolves(modelMock);
         setDefaultVariantStub = sinon.stub(product, 'setDefaultVariant').resolves(productFixture);
       });

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -628,8 +628,8 @@ describe('Product Component class', () => {
         const updateQuantityStub = sinon.stub(product, 'updateQuantity');
         product.onQuantityBlur(event, target);
         assert.calledOnce(updateQuantityStub);
-        const value = updateQuantityStub.getCall(0).args[0]();
-        assert.equal(value, 10);
+        const calculatedValue = updateQuantityStub.getCall(0).args[0]();
+        assert.equal(calculatedValue, 10);
         updateQuantityStub.restore();
       });
     });
@@ -639,8 +639,8 @@ describe('Product Component class', () => {
         const updateQuantityStub = sinon.stub(product, 'updateQuantity');
         product.onQuantityIncrement(3);
         assert.calledOnce(updateQuantityStub);
-        const value = updateQuantityStub.getCall(0).args[0](2);
-        assert.equal(value, 5);
+        const calculatedValue = updateQuantityStub.getCall(0).args[0](2);
+        assert.equal(calculatedValue, 5);
         updateQuantityStub.restore();
       });
     });

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -628,8 +628,8 @@ describe('Product Component class', () => {
         const updateQuantityStub = sinon.stub(product, 'updateQuantity');
         product.onQuantityBlur(event, target);
         assert.calledOnce(updateQuantityStub);
-        const calculatedValue = updateQuantityStub.getCall(0).args[0]();
-        assert.equal(calculatedValue, 10);
+        const callbackValue = updateQuantityStub.getCall(0).args[0]();
+        assert.equal(callbackValue, 10);
         updateQuantityStub.restore();
       });
     });
@@ -639,8 +639,8 @@ describe('Product Component class', () => {
         const updateQuantityStub = sinon.stub(product, 'updateQuantity');
         product.onQuantityIncrement(3);
         assert.calledOnce(updateQuantityStub);
-        const calculatedValue = updateQuantityStub.getCall(0).args[0](2);
-        assert.equal(calculatedValue, 5);
+        const callbackValue = updateQuantityStub.getCall(0).args[0](2);
+        assert.equal(callbackValue, 5);
         updateQuantityStub.restore();
       });
     });


### PR DESCRIPTION
- Moved sdkFetch into other prototype methods
- Refactored sdkFetch to not re-instantiate a new product component
- Updated tests for setupModel
- Created tests for:
  - onBlockButtonKeyup
  - onOptionSelect
  - onQuantityBlur
  - onQuantityIncrement
  - closeCartOnBgClick