### PR TITLE
add alt text to images

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -144,7 +144,7 @@ export default class Product extends Component {
       src = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptionsLarge);
       srcOriginal = this.selectedImage.src;
-      altText = this.selectedImage.altText;
+      altText = (this.selectedImage.altText || this.model.title);
     } else if (this.selectedVariant.image == null && this.model.images[0] == null) {
       id = null;
       src = '';
@@ -156,14 +156,15 @@ export default class Product extends Component {
       src = this.model.images[0].src;
       srcLarge = this.props.client.image.helpers.imageForSize(this.model.images[0], imageOptionsLarge);
       srcOriginal = this.model.images[0].src;
-      altText = this.model.images[0].altText;
+      altText = (this.model.images[0].altText || this.model.title);
     } else {
       id = this.selectedVariant.image.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptionsLarge);
       srcOriginal = this.selectedVariant.image.src;
-      altText = this.selectedVariant.image.altText;
+      altText = (this.selectedVariant.image.altText || this.model.title);
     }
+
     return {id, src, srcLarge, srcOriginal, altText};
   }
 
@@ -218,13 +219,15 @@ export default class Product extends Component {
   }
 
   get carouselImages() {
+    let productTitle = this.model.title;
+
     return this.model.images.map((image) => {
       return {
         id: image.id,
         src: image.src,
         carouselSrc: this.props.client.image.helpers.imageForSize(image, {maxWidth: 100, maxHeight: 100}),
         isSelected: image.id === this.currentImage.id,
-        altText: image.altText,
+        altText: (image.altText || productTitle),
       };
     });
   }

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -774,9 +774,8 @@ export default class Product extends Component {
     return model;
   }
 
-
-  imageAltText(string) {
-    return (string || this.model.title);
+  imageAltText(altText) {
+    return altText || this.model.title;
   }
 
 }

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -144,7 +144,7 @@ export default class Product extends Component {
       src = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptionsLarge);
       srcOriginal = this.selectedImage.src;
-      altText = (this.selectedImage.altText || this.model.title);
+      altText = this.imageAltText(this.selectedImage.altText);
     } else if (this.selectedVariant.image == null && this.model.images[0] == null) {
       id = null;
       src = '';
@@ -156,13 +156,13 @@ export default class Product extends Component {
       src = this.model.images[0].src;
       srcLarge = this.props.client.image.helpers.imageForSize(this.model.images[0], imageOptionsLarge);
       srcOriginal = this.model.images[0].src;
-      altText = (this.model.images[0].altText || this.model.title);
+      altText = this.imageAltText(this.model.images[0].altText);
     } else {
       id = this.selectedVariant.image.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptionsLarge);
       srcOriginal = this.selectedVariant.image.src;
-      altText = (this.selectedVariant.image.altText || this.model.title);
+      altText = this.imageAltText(this.selectedVariant.image.altText);
     }
 
     return {id, src, srcLarge, srcOriginal, altText};
@@ -219,15 +219,13 @@ export default class Product extends Component {
   }
 
   get carouselImages() {
-    let productTitle = this.model.title;
-
     return this.model.images.map((image) => {
       return {
         id: image.id,
         src: image.src,
         carouselSrc: this.props.client.image.helpers.imageForSize(image, {maxWidth: 100, maxHeight: 100}),
         isSelected: image.id === this.currentImage.id,
-        altText: (image.altText || productTitle),
+        altText: this.imageAltText(image.altText),
       };
     });
   }
@@ -775,4 +773,10 @@ export default class Product extends Component {
     this.selectedVariant = selectedVariant;
     return model;
   }
+
+
+  imageAltText(string) {
+    return (string || this.model.title);
+  }
+
 }

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -127,6 +127,7 @@ export default class Product extends Component {
     let src;
     let srcLarge;
     let srcOriginal;
+    let altText;
 
     const imageOptions = {
       maxWidth: imageSize,
@@ -143,23 +144,27 @@ export default class Product extends Component {
       src = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedImage, imageOptionsLarge);
       srcOriginal = this.selectedImage.src;
+      altText = this.selectedImage.altText;
     } else if (this.selectedVariant.image == null && this.model.images[0] == null) {
       id = null;
       src = '';
       srcLarge = '';
       srcOriginal = '';
+      altText = '';
     } else if (this.selectedVariant.image == null) {
       id = this.model.images[0].id;
       src = this.model.images[0].src;
       srcLarge = this.props.client.image.helpers.imageForSize(this.model.images[0], imageOptionsLarge);
       srcOriginal = this.model.images[0].src;
+      altText = this.model.images[0].altText;
     } else {
       id = this.selectedVariant.image.id;
       src = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptions);
       srcLarge = this.props.client.image.helpers.imageForSize(this.selectedVariant.image, imageOptionsLarge);
       srcOriginal = this.selectedVariant.image.src;
+      altText = this.selectedVariant.image.altText;
     }
-    return {id, src, srcLarge, srcOriginal};
+    return {id, src, srcLarge, srcOriginal, altText};
   }
 
   /**
@@ -219,6 +224,7 @@ export default class Product extends Component {
         src: image.src,
         carouselSrc: this.props.client.image.helpers.imageForSize(image, {maxWidth: 100, maxHeight: 100}),
         isSelected: image.id === this.currentImage.id,
+        altText: image.altText,
       };
     });
   }

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -27,7 +27,7 @@ const productTemplate = {
                       </div>
                       <div class="{{data.classes.product.carousel}}">
                         {{#data.carouselImages}}
-                        <a data-element="product.carouselitem" href="{{src}}" class="{{data.classes.product.carouselItem}} {{#isSelected}} {{data.classes.product.carouselItemSelected}} {{/isSelected}}" data-image-id="{{id}}" style="background-image: url({{carouselSrc}})"></a>
+                        <a data-element="product.carouselitem" alt="{{altText}}" href="{{src}}" class="{{data.classes.product.carouselItem}} {{#isSelected}} {{data.classes.product.carouselItemSelected}} {{/isSelected}}" data-image-id="{{id}}" style="background-image: url({{carouselSrc}})"></a>
                         {{/data.carouselImages}}
                       </div>
                     </div>`,

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -27,7 +27,7 @@ const productTemplate = {
                       </div>
                       <div class="{{data.classes.product.carousel}}">
                         {{#data.carouselImages}}
-                        <a data-element="product.carouselitem" alt="{{altText}}" href="{{src}}" class="{{data.classes.product.carouselItem}} {{#isSelected}} {{data.classes.product.carouselItemSelected}} {{/isSelected}}" data-image-id="{{id}}" style="background-image: url({{carouselSrc}})"></a>
+                        <a data-element="product.carouselitem" aria-label="{{altText}}" href="{{src}}" class="{{data.classes.product.carouselItem}} {{#isSelected}} {{data.classes.product.carouselItemSelected}} {{/isSelected}}" data-image-id="{{id}}" style="background-image: url({{carouselSrc}})"></a>
                         {{/data.carouselImages}}
                       </div>
                     </div>`,

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -12,7 +12,7 @@ const quantityTemplate = `<div class="{{data.classes.product.quantity}} {{data.q
 const buttonTemplate = '<div class="{{data.classes.product.buttonWrapper}}" data-element="product.buttonWrapper"><button {{#data.buttonDisabled}}disabled{{/data.buttonDisabled}} class="{{data.classes.product.button}} {{data.buttonClass}}" data-element="product.button">{{data.buttonText}}</button></div>';
 
 const productTemplate = {
-  img: '{{#data.currentImage.srcLarge}}<div class="{{data.classes.product.imgWrapper}}" data-element="product.imgWrapper"><img data-element="product.img" class="{{data.classes.product.img}}" src="{{data.currentImage.srcLarge}}" /></div>{{/data.currentImage.srcLarge}}',
+  img: '{{#data.currentImage.srcLarge}}<div class="{{data.classes.product.imgWrapper}}" data-element="product.imgWrapper"><img alt="{{data.currentImage.altText}}" data-element="product.img" class="{{data.classes.product.img}}" src="{{data.currentImage.srcLarge}}" /></div>{{/data.currentImage.srcLarge}}',
   imgWithCarousel: `<div class="{{data.classes.product.imgWrapper}}" data-element="product.imageWrapper">
                       <div class="main-image-wrapper">
                         <button type="button" class="carousel-button carousel-button--previous">

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -19,7 +19,7 @@ const productTemplate = {
                           Left
                           <img class="carousel-button-arrow" src="//sdks.shopifycdn.com/buy-button/latest/arrow.svg" alt="Carousel Arrow"/>
                         </button>
-                        <img class="{{data.classes.product.img}}" src="{{data.currentImage.src}}" data-element="product.img" />
+                        <img class="{{data.classes.product.img}}" alt="{{data.currentImage.altText}}" src="{{data.currentImage.src}}" data-element="product.img" />
                         <button type="button" class="carousel-button carousel-button--next">
                           Right
                           <img class="carousel-button-arrow" src="//sdks.shopifycdn.com/buy-button/latest/arrow.svg" alt="Carousel Arrow"/>

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1093,8 +1093,8 @@ describe('Product Component class', () => {
         assert.equal(product.imageAltText('test alt'), 'test alt');
       })
 
-      it('outputs the images alt text value as the images title when alt text is not passed', () => {
-        assert.equal(product.imageAltText(), 'test');
+      it('returns the image title when alt text passed in is null', () => {
+        assert.equal(product.imageAltText(null), 'test');
       })
     });
 

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1201,13 +1201,17 @@ describe('Product Component class', () => {
             product.selectedImage = {
               id: '123',
               src: 'hat.jpg',
+              altText: 'red hat',
             };
+
             const expectedObject = {
               id: product.selectedImage.id,
               src: expectedSrc,
               srcLarge: expectedSrcLarge,
               srcOriginal: product.selectedImage.src,
+              altText: product.selectedImage.altText,
             };
+
             assert.deepEqual(product.image, expectedObject);
             assert.calledTwice(imageForSizeStub);
             assert.calledWith(imageForSizeStub.getCall(0), product.selectedImage, expectedSrc);
@@ -1223,6 +1227,7 @@ describe('Product Component class', () => {
               src: '',
               srcLarge: '',
               srcOriginal: '',
+              altText: '',
             };
             assert.deepEqual(product.image, expectedObject);
           });
@@ -1236,6 +1241,7 @@ describe('Product Component class', () => {
               src: firstImage.src,
               srcLarge: expectedSrcLarge,
               srcOriginal: firstImage.src,
+              altText: firstImage.altText,
             };
             assert.deepEqual(product.image, expectedObject);
             assert.calledOnce(imageForSizeStub);
@@ -1248,6 +1254,7 @@ describe('Product Component class', () => {
               image: {
                 id: '456',
                 src: 'top.jpg',
+                altText: 'tip top',
               },
             };
             const expectedObject = {
@@ -1255,6 +1262,7 @@ describe('Product Component class', () => {
               src: expectedSrc,
               srcLarge: expectedSrcLarge,
               srcOriginal: product.selectedVariant.image.src,
+              altText: product.selectedVariant.image.altText,
             };
             assert.deepEqual(product.image, expectedObject);
             assert.calledTwice(imageForSizeStub);

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1087,6 +1087,17 @@ describe('Product Component class', () => {
       });
     });
 
+
+    describe('imageAltText()', () => {
+      it('outputs the images alt text value when alt text is passed', () => {
+        assert.equal(product.imageAltText('test alt'), 'test alt');
+      })
+
+      it('outputs the images alt text value as the images title when alt text is not passed', () => {
+        assert.equal(product.imageAltText(), 'test');
+      })
+    });
+
     describe('getters', () => {
       describe('shouldUpdateImage', () => {
         beforeEach(async () => {
@@ -1186,14 +1197,6 @@ describe('Product Component class', () => {
           assert.equal(image.src.maxHeight, image.src.maxWidth * 1.5);
           assert.equal(image.srcLarge.maxHeight, image.srcLarge.maxWidth * 1.5);
         });
-
-        it('outputs the images alt text value when alt text is passed', () => {
-          assert.equal(product.imageAltText("test alt"), "test alt");
-        })
-
-        it('outputs the images alt text value as the images title when alt text is not passed', () => {
-          assert.equal(product.imageAltText(), "test");
-        })
 
         describe('return object', () => {
           let expectedSrc;

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1241,7 +1241,7 @@ describe('Product Component class', () => {
               src: firstImage.src,
               srcLarge: expectedSrcLarge,
               srcOriginal: firstImage.src,
-              altText: firstImage.altText,
+              altText: (firstImage.altText || 'test'),
             };
             assert.deepEqual(product.image, expectedObject);
             assert.calledOnce(imageForSizeStub);

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1089,6 +1089,10 @@ describe('Product Component class', () => {
 
 
     describe('imageAltText()', () => {
+      beforeEach(async () => {
+        await product.init(testProductCopy);
+      });
+
       it('returns the passed in image alt text if it is valid', () => {
         assert.equal(product.imageAltText('test alt'), 'test alt');
       })

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1241,8 +1241,9 @@ describe('Product Component class', () => {
               src: firstImage.src,
               srcLarge: expectedSrcLarge,
               srcOriginal: firstImage.src,
-              altText: (firstImage.altText || 'test'),
+              altText: 'test',
             };
+
             assert.deepEqual(product.image, expectedObject);
             assert.calledOnce(imageForSizeStub);
             assert.calledWith(imageForSizeStub, firstImage, expectedSrcLarge);

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1187,6 +1187,14 @@ describe('Product Component class', () => {
           assert.equal(image.srcLarge.maxHeight, image.srcLarge.maxWidth * 1.5);
         });
 
+        it('outputs the images alt text value when alt text is passed', () => {
+          assert.equal(product.imageAltText("test alt"), "test alt");
+        })
+
+        it('outputs the images alt text value as the images title when alt text is not passed', () => {
+          assert.equal(product.imageAltText(), "test");
+        })
+
         describe('return object', () => {
           let expectedSrc;
           let expectedSrcLarge;

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1089,7 +1089,7 @@ describe('Product Component class', () => {
 
 
     describe('imageAltText()', () => {
-      it('outputs the images alt text value when alt text is passed', () => {
+      it('returns the passed in image alt text if it is valid', () => {
         assert.equal(product.imageAltText('test alt'), 'test alt');
       })
 


### PR DESCRIPTION
**Description**
As a developer
I want the alt text variable exposed on my Product Detail Page (PDP) images
So that I can properly set the alt text data, which exists in shopify, on the `alt` attribute of the main image and `aria-label` attribute on the carousel images.

**Acceptance Criteria**
* the `alt` and `aria-label` attribute data comes from the image alt text field in the shopify store
* the `aria-label` attribute is set the selected carousel image
* the `aria-label` attribute is set on the carousel image
* the `alt` attribute is set on the main image
