### PR TITLE
Bump js buy sdk to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "morphdom": "1.4.6",
     "mustache": "2.2.1",
     "node-sass": "3.8.0",
-    "shopify-buy": "1.11.0",
+    "shopify-buy": "2.0.1",
     "uglify-js": "2.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5460,10 +5460,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-1.11.0.tgz#eb5f2e8c877e4baadac55082e7d41f34669a1197"
-  integrity sha512-elnbSzveyVhVlyg9TnmBimrvQmH1+AKehWOfiyDWTUkRVUmJeUzFwx2ghRREwpt7F5qQtryGEtH90obhzlMNgg==
+shopify-buy@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.0.1.tgz#3b9beae18149e86f90b4299c96ecf345eea47b24"
+  integrity sha512-VSrl4JX2raavX4MLdjy//LKdlVik88UmFC4XA/o38pQgq97Tn3JgIkARmoNVOu8QGGECJM4jQD6jHtX/gdoDCQ==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
We want to pull in the latest changes from js-buy-sdk to fix the automatic discounts error. To achieve this error, you need to set up an automatic discount in admin (such as Buy X Get Y), and try to add X and Y to your cart. 

If you want to 🎩 : 
* Run locally on master and verify that the error is reproducible when adding X and Y to cart
* Run on this branch and verify that both X and Y can be added to cart without error