### PR TITLE
Update tests related to image alt text

### DIFF
--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1098,7 +1098,7 @@ describe('Product Component class', () => {
       })
 
       it('returns the image title when alt text passed in is null', () => {
-        assert.equal(product.imageAltText(null), 'test');
+        assert.equal(product.imageAltText(null), product.model.title);
       })
     });
 
@@ -1159,16 +1159,20 @@ describe('Product Component class', () => {
 
       describe('image', () => {
         let imageForSizeStub;
+        let imageAltTextStub;
+        const mockAltText = 'mock alt text';
 
         beforeEach(async () => {
           await product.init(testProductCopy);
           imageForSizeStub = sinon.stub(product.props.client.image.helpers, 'imageForSize').callsFake((image, dimensions) => {
             return dimensions;
           });
+          imageAltTextStub = sinon.stub(product, 'imageAltText').returns(mockAltText);
         });
 
         afterEach(() => {
           imageForSizeStub.restore();
+          imageAltTextStub.restore();
         });
 
         it('returns null if there is no selected variant and no image with carousel in options', () => {
@@ -1212,7 +1216,7 @@ describe('Product Component class', () => {
             expectedSrcLarge = {maxWidth: 550, maxHeight: 550 * 1.5};
           });
 
-          it('returns object with id, src, srcLarge, and srcOriginal from selected image if selected image exists', () => {
+          it('returns object with id, src, srcLarge, srcOriginal, and altText from selected image if selected image exists', () => {
             product.selectedImage = {
               id: '123',
               src: 'hat.jpg',
@@ -1224,16 +1228,18 @@ describe('Product Component class', () => {
               src: expectedSrc,
               srcLarge: expectedSrcLarge,
               srcOriginal: product.selectedImage.src,
-              altText: product.selectedImage.altText,
+              altText: mockAltText,
             };
 
             assert.deepEqual(product.image, expectedObject);
             assert.calledTwice(imageForSizeStub);
             assert.calledWith(imageForSizeStub.getCall(0), product.selectedImage, expectedSrc);
             assert.calledWith(imageForSizeStub.getCall(1), product.selectedImage, expectedSrcLarge);
+            assert.calledOnce(imageAltTextStub);
+            assert.calledWith(imageAltTextStub, product.selectedImage.altText);
           });
 
-          it('returns object with id to null and src, srcLarge, and srcOriginal to empty string if selected variant does not have an image and there are no images in the model', () => {
+          it('returns object with id to null and src, srcLarge, srcOriginal, and altText to empty string if selected variant does not have an image and there are no images in the model', () => {
             product.selectedImage = null;
             product.selectedVariant = {image: null};
             product.model.images = [];
@@ -1245,9 +1251,10 @@ describe('Product Component class', () => {
               altText: '',
             };
             assert.deepEqual(product.image, expectedObject);
+            assert.notCalled(imageAltTextStub);
           });
 
-          it('returns object with id, src, srcLarge, and srcOriginal from first image in model if selected variant does not have an image', () => {
+          it('returns object with id, src, srcLarge, srcOriginal, and altText from first image in model if selected variant does not have an image', () => {
             product.selectedImage = null;
             product.selectedVariant = {image: null};
             const firstImage = product.model.images[0];
@@ -1256,15 +1263,17 @@ describe('Product Component class', () => {
               src: firstImage.src,
               srcLarge: expectedSrcLarge,
               srcOriginal: firstImage.src,
-              altText: 'test',
+              altText: mockAltText,
             };
 
             assert.deepEqual(product.image, expectedObject);
             assert.calledOnce(imageForSizeStub);
             assert.calledWith(imageForSizeStub, firstImage, expectedSrcLarge);
+            assert.calledOnce(imageAltTextStub);
+            assert.calledWith(imageAltTextStub, firstImage.altText);
           });
 
-          it('returns object with id, src, srcLarge, and srcOriginal from selected variant as default', () => {
+          it('returns object with id, src, srcLarge, srcOriginal, and altText from selected variant as default', () => {
             product.selectedImage = null;
             product.selectedVariant = {
               image: {
@@ -1278,12 +1287,14 @@ describe('Product Component class', () => {
               src: expectedSrc,
               srcLarge: expectedSrcLarge,
               srcOriginal: product.selectedVariant.image.src,
-              altText: product.selectedVariant.image.altText,
+              altText: mockAltText,
             };
             assert.deepEqual(product.image, expectedObject);
             assert.calledTwice(imageForSizeStub);
             assert.calledWith(imageForSizeStub.getCall(0), product.selectedVariant.image, expectedSrc);
             assert.calledWith(imageForSizeStub.getCall(1), product.selectedVariant.image, expectedSrcLarge);
+            assert.calledOnce(imageAltTextStub);
+            assert.calledWith(imageAltTextStub, product.selectedVariant.image.altText);
           });
         });
       });


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
* Stub out imageAltText
* Update some `image > return object` test names to include `altText`
* Update the assertion in the `imageAltText` test to use the model's product title, instead of a hardcoded value pulled from the fixture

cc: @robskrob 