### PR TITLE
Add notes field to cart

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -67,6 +67,7 @@ export default class Cart extends Component {
       [`click ${this.selectors.lineItem.quantityDecrement}`]: this.onQuantityIncrement.bind(this, -1),
       [`click ${this.selectors.cart.button}`]: this.onCheckout.bind(this),
       [`blur ${this.selectors.lineItem.quantityInput}`]: this.onQuantityBlur.bind(this),
+      [`blur ${this.selectors.cart.note}`]: this.onNoteBlur.bind(this),
     }, this.options.DOMEvents);
   }
 
@@ -96,6 +97,8 @@ export default class Cart extends Component {
       lineItemsHtml: this.lineItemsHtml,
       isEmpty: this.isEmpty,
       formattedTotal: this.formattedTotal,
+      contents: this.options.contents,
+      cartNote: this.cartNote,
     });
   }
 
@@ -113,6 +116,10 @@ export default class Cart extends Component {
    */
   get isEmpty() {
     return this.model.lineItems.length < 1;
+  }
+
+  get cartNote() {
+    return this.model.note;
   }
 
   get wrapperClass() {
@@ -246,6 +253,10 @@ export default class Cart extends Component {
     this.setQuantity(target, () => parseInt(target.value, 10));
   }
 
+  onNoteBlur(evt) {
+    this.setNote(evt);
+  }
+
   onQuantityIncrement(qty, evt, target) {
     this.setQuantity(target, (prevQty) => prevQty + qty);
   }
@@ -264,6 +275,14 @@ export default class Cart extends Component {
     const item = this.model.lineItems.find((lineItem) => lineItem.id === id);
     const newQty = fn(item.quantity);
     return this.props.tracker.trackMethod(this.updateItem.bind(this), 'Update Cart', this.cartItemTrackingInfo(item, newQty))(id, newQty);
+  }
+
+  setNote(evt) {
+    const note = evt.target.value;
+    return this.props.client.checkout.updateAttributes(this.model.id, {note}).then((checkout) => {
+      this.model = checkout;
+      return checkout;
+    });
   }
 
   /**

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -67,7 +67,7 @@ export default class Cart extends Component {
       [`click ${this.selectors.lineItem.quantityDecrement}`]: this.onQuantityIncrement.bind(this, -1),
       [`click ${this.selectors.cart.button}`]: this.onCheckout.bind(this),
       [`blur ${this.selectors.lineItem.quantityInput}`]: this.onQuantityBlur.bind(this),
-      [`blur ${this.selectors.cart.note}`]: this.onNoteBlur.bind(this),
+      [`blur ${this.selectors.cart.note}`]: this.setNote.bind(this),
     }, this.options.DOMEvents);
   }
 
@@ -251,10 +251,6 @@ export default class Cart extends Component {
 
   onQuantityBlur(evt, target) {
     this.setQuantity(target, () => parseInt(target.value, 10));
-  }
-
-  onNoteBlur(evt) {
-    this.setNote(evt);
   }
 
   onQuantityIncrement(qty, evt, target) {

--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -195,6 +195,7 @@ const defaults = {
       title: true,
       lineItems: true,
       footer: true,
+      note: false,
     },
     order: ['title', 'lineItems', 'footer'],
     classes: {
@@ -211,7 +212,11 @@ const defaults = {
       button: 'shopify-buy__btn shopify-buy__btn--cart-checkout',
       close: 'shopify-buy__btn--close',
       cartScroll: 'shopify-buy__cart-scroll',
+      cartScrollSmall: 'shopify-buy__cart-scroll--small',
       empty: 'shopify-buy__cart-empty-text',
+      note: 'shopify-buy__cart__note',
+      noteDescription: 'shopify-buy__cart__note__description',
+      noteTextArea: 'shopify-buy__cart__note__text-area',
     },
     text: {
       title: 'Cart',
@@ -220,6 +225,7 @@ const defaults = {
       total: 'SUBTOTAL',
       currency: 'CAD',
       notice: 'Shipping and discount codes are added at checkout.',
+      noteDescription: 'Special instructions for seller',
     },
   },
   lineItem: {

--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -212,7 +212,7 @@ const defaults = {
       button: 'shopify-buy__btn shopify-buy__btn--cart-checkout',
       close: 'shopify-buy__btn--close',
       cartScroll: 'shopify-buy__cart-scroll',
-      cartScrollSmall: 'shopify-buy__cart-scroll--small',
+      cartScrollWithCartNote: 'shopify-buy__cart-scroll--cart-note',
       empty: 'shopify-buy__cart-empty-text',
       note: 'shopify-buy__cart__note',
       noteDescription: 'shopify-buy__cart__note__description',

--- a/src/styles/embeds/sass/components/cart.css
+++ b/src/styles/embeds/sass/components/cart.css
@@ -72,7 +72,7 @@
   width: 100%;
 }
 
-.shopify-buy__cart-scroll--small {
+.shopify-buy__cart-scroll--cart-note {
   padding: 70px 0 200px 0;
 }
 

--- a/src/styles/embeds/sass/components/cart.css
+++ b/src/styles/embeds/sass/components/cart.css
@@ -72,6 +72,10 @@
   width: 100%;
 }
 
+.shopify-buy__cart-scroll--small {
+  padding: 70px 0 200px 0;
+}
+
 .shopify-buy__cart-items {
   overflow: hidden;
   overflow-y: auto;
@@ -160,6 +164,23 @@
   clear: both;
   padding-top: 10px;
   text-align: center;
+  color: var(--color-title);
+}
+
+.shopify-buy__cart__note {
+  clear: both;
+  padding-top: 10px;
+}
+
+.shopify-buy__cart__note__description {
+  font-size: 11px;
+  color: var(--color-title);
+}
+
+.shopify-buy__cart__note__text-area {
+  resize: none;
+  font-size: 11px;
+  width: 100%;
   color: var(--color-title);
 }
 

--- a/src/templates/cart.js
+++ b/src/templates/cart.js
@@ -6,7 +6,7 @@ const cartTemplates = {
               <span class="visuallyhidden">Close</span>
              </button>
           </div>`,
-  lineItems: `<div class="{{data.classes.cart.cartScroll}} {{#data.contents.note}}{{data.classes.cart.cartScrollSmall}}{{/data.contents.note}}" data-elemenmt="cart.cartScroll">
+  lineItems: `<div class="{{data.classes.cart.cartScroll}} {{#data.contents.note}}{{data.classes.cart.cartScrollWithCartNote}}{{/data.contents.note}}" data-element="cart.cartScroll">
                 {{#data.isEmpty}}<p class="{{data.classes.cart.empty}} {{data.classes.cart.emptyCart}}" data-element="cart.empty">{{data.text.empty}}</p>{{/data.isEmpty}}
                 <div class="{{data.classes.cart.lineItems}}" data-element="cart.lineItems">{{{data.lineItemsHtml}}}</div>
               </div>`,

--- a/src/templates/cart.js
+++ b/src/templates/cart.js
@@ -6,7 +6,7 @@ const cartTemplates = {
               <span class="visuallyhidden">Close</span>
              </button>
           </div>`,
-  lineItems: `<div class="{{data.classes.cart.cartScroll}}" data-elemenmt="cart.cartScroll">
+  lineItems: `<div class="{{data.classes.cart.cartScroll}} {{#data.contents.note}}{{data.classes.cart.cartScrollSmall}}{{/data.contents.note}}" data-elemenmt="cart.cartScroll">
                 {{#data.isEmpty}}<p class="{{data.classes.cart.empty}} {{data.classes.cart.emptyCart}}" data-element="cart.empty">{{data.text.empty}}</p>{{/data.isEmpty}}
                 <div class="{{data.classes.cart.lineItems}}" data-element="cart.lineItems">{{{data.lineItemsHtml}}}</div>
               </div>`,
@@ -14,6 +14,12 @@ const cartTemplates = {
             <div class="{{data.classes.cart.footer}}" data-element="cart.footer">
               <p class="{{data.classes.cart.subtotalText}}" data-element="cart.total">{{data.text.total}}</p>
               <p class="{{data.classes.cart.subtotal}}" data-element="cart.subtotal">{{data.formattedTotal}}</p>
+              {{#data.contents.note}}
+                <div class="{{data.classes.cart.note}}" data-element="cart.note">
+                  <p class="{{data.classes.cart.noteDescription}}" data-element="cart.noteDescription">{{data.text.noteDescription}}</p>
+                  <textarea class="{{data.classes.cart.noteTextArea}}" data-element="cart.noteTextArea" rows="3"/>{{data.cartNote}}</textarea>
+                </div>
+              {{/data.contents.note}}
               <p class="{{data.classes.cart.notice}}" data-element="cart.notice">{{data.text.notice}}</p>
               <button class="{{data.classes.cart.button}}" type="button" data-element="cart.button">{{data.text.button}}</button>
             </div>

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -18,8 +18,12 @@ describe('Cart class', () => {
     cart = new Cart({
       options: {
         cart: {
-          viewData: {
-            test: 'test string',
+          contents: {
+            title: false,
+            note: true,
+          },
+          text: {
+            notice: 'test',
           },
         },
       },
@@ -382,11 +386,11 @@ describe('Cart class', () => {
       onQuantityBlurStub.restore();
     });
 
-    it('binds onNoteBlur to blur on cart note field', () => {
-      const onNoteBlurStub = sinon.stub(cart, 'onNoteBlur');
+    it('binds setNote to blur on cart note field', () => {
+      const setNoteStub = sinon.stub(cart, 'setNote');
       cart.DOMEvents[`blur ${cart.selectors.cart.note}`]();
-      assert.calledOnce(onNoteBlurStub);
-      onNoteBlurStub.restore();
+      assert.calledOnce(setNoteStub);
+      setNoteStub.restore();
     });
   });
 
@@ -419,10 +423,6 @@ describe('Cart class', () => {
       assert.equal(viewData.id, cart.model.id);
       assert.deepEqual(viewData.lineItems, cart.model.lineItems);
       assert.equal(viewData.subtotalPrice, cart.model.subtotalPrice);
-    });
-
-    it('returns an object merged with options view data', () => {
-      assert.equal(viewData.test, cart.options.viewData.test);
     });
 
     it('returns an object with text', () => {
@@ -460,19 +460,6 @@ describe('Cart class', () => {
       cart.model.note = note;
 
       assert.equal(cart.cartNote, cart.model.note);
-    });
-  });
-
-  describe('onNoteBlur()', () => {
-    it('calls set note with the event', () => {
-      const setNoteStub = sinon.stub(cart, 'setNote');
-      const event = new Event('test');
-
-      cart.onNoteBlur(event);
-      assert.calledOnce(setNoteStub);
-      assert.calledWith(setNoteStub, event);
-
-      setNoteStub.restore();
     });
   });
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Expose a note field at the cart level, which will populate the checkout object's [note field](https://help.shopify.com/en/api/custom-storefronts/storefront-api/reference/object/checkout#note). 

I've added a new contents option called `note`, a new text field called `noteDescription`, as well as several classes which can be used to override the default styling. 
The styling of the cart note follows the existing convention of using padding around the scrollable area where the line items appear. However, this method does not allow for a long cart notice or note description text without cutting off some of the scrollable area.  This was the case before as well, for long cart notice strings. 

To 🎩 : 
* Check that the new config options work and allow you to customize the cart note display
* Check that the cart note persists if you enter some text, close your browser, and come back to the cart
* Proceed with a checkout (easiest way is to have $0 products), and check that the cart note appears on the order page in the admin