### PR TITLE
Update docs with new cart config options

### DIFF
--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -269,6 +269,7 @@ var contents = {
   title: true,
   lineItems: true,
   footer: true,
+  note: false,
 },
 ```
 
@@ -282,6 +283,7 @@ var text = {
   total: 'Total',
   currency: 'CAD',
   notice: 'Shipping and discount codes are added at checkout.',
+  noteDescription: 'Special instructions for seller',
 },
 ```
 


### PR DESCRIPTION
Add the new cart note related configuration defaults to the docs, to give developers an indication of how to enable the feature. 

Should match the [cart > contents > note default](https://github.com/Shopify/buy-button-js/blob/master/src/defaults/components.js#L198) and [cart > text > noteDescription default](https://github.com/Shopify/buy-button-js/blob/master/src/defaults/components.js#L228)