### PR TITLE
Add support to lineItemsSubtotalPrice field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+### v0.11.0 (March 29, 2019)
+- Bump `shopify-buy` dependency to v2.2.0.
+- Asserts `lineItemsSubtotalPrice` is exposed.
+- Add a `formattedLineItemsSubtotal` field to cart view model. The new field consists in a sum of all line items prices without any discount, taxes or shipping rates applications.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "morphdom": "1.4.6",
     "mustache": "2.2.1",
     "node-sass": "3.8.0",
-    "shopify-buy": "2.0.1",
+    "shopify-buy": "2.2.0",
     "uglify-js": "2.7.0"
   }
 }

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -110,6 +110,10 @@ export default class Cart extends Component {
     return formatMoney(this.model.subtotalPrice, this.moneyFormat);
   }
 
+  get formattedLineItemsSubtotal() {
+    return formatMoney(this.model.lineItemsSubtotalPrice.amount, this.moneyFormat);
+  }
+
   /**
    * whether cart is empty
    * @return {Boolean}

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -164,7 +164,7 @@ describe('Cart class', () => {
 
     it('calls sanitizeCheckout then updateCache with the new checkout', () => {
       localStorage.setItem(cart.localStorageCheckoutKey, 123);
-      
+
       const checkout = {id: 1111, lineItems: [
         {id: 1112, variant: null},
         {id: 1113, variant: {id: 1114}},
@@ -173,7 +173,7 @@ describe('Cart class', () => {
       const sanitizedCheckout = {id: 1111, lineItems: [
         {id: 1113, variant: {id: 1114}},
       ]};
-      
+
       const fetchCart = sinon.stub(cart.props.client.checkout, 'fetch').resolves(checkout);
       const sanitizeCheckout = sinon.stub(cart, 'sanitizeCheckout').resolves(sanitizedCheckout);
       const updateCache = sinon.stub(cart, 'updateCache').resolves();
@@ -217,7 +217,7 @@ describe('Cart class', () => {
         {id: 1113, variant: {id: 1114}},
       ]};
       const removeLineItems = sinon.stub(cart.props.client.checkout, 'removeLineItems').resolves(sanitizedCheckout);
-      
+
       return cart.sanitizeCheckout(checkout).then((data) => {
         assert.deepEqual(data, sanitizedCheckout);
         assert.calledOnce(removeLineItems);
@@ -297,6 +297,18 @@ describe('Cart class', () => {
         subtotalPrice: '20.00',
       }
       assert.equal(cart.formattedTotal, '$20.00');
+    });
+  });
+
+  describe('get formattedLineItemsSubtotal', () => {
+    it.only('uses money helper to return currency formatted value', () => {
+      cart.model = {
+        lineItemsSubtotalPrice: {
+          amount: '30.00',
+          currencyCode: 'USD'
+        }
+      }
+      assert.equal(cart.formattedLineItemsSubtotal, '$30.00');
     });
   });
 
@@ -414,6 +426,10 @@ describe('Cart class', () => {
         lineItems,
         note: 'test cart note',
         subtotalPrice: '123.00',
+        lineItemsSubtotalPrice: {
+          amount: '130.00',
+          currencyCode: 'USD'
+        },
       };
       cart.lineItemCache = lineItems;
       viewData = cart.viewData;
@@ -423,6 +439,7 @@ describe('Cart class', () => {
       assert.equal(viewData.id, cart.model.id);
       assert.deepEqual(viewData.lineItems, cart.model.lineItems);
       assert.equal(viewData.subtotalPrice, cart.model.subtotalPrice);
+      assert.equal(viewData.lineItemsSubtotalPrice, cart.model.lineItemsSubtotalPrice);
     });
 
     it('returns an object with text', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5460,10 +5460,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.0.1.tgz#3b9beae18149e86f90b4299c96ecf345eea47b24"
-  integrity sha512-VSrl4JX2raavX4MLdjy//LKdlVik88UmFC4XA/o38pQgq97Tn3JgIkARmoNVOu8QGGECJM4jQD6jHtX/gdoDCQ==
+shopify-buy@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.2.0.tgz#00e46aa4765f9279b924165c01928c290ea5cbdf"
+  integrity sha512-UK7EqmFs+tNglI9Dw1UR4rl/ZKXb8E0XPXQDXXKHMNMGfRShvqZ3wiTV7icnVhjjeig14SYRcc60R/ifkfU8LQ==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
- Bump `shopify-buy` dependency to `v2.2.0`.
- Asserts `lineItemsSubtotalPrice` is exposed.
- Expose `formattedLineItemsSubtotal` field to cart view model. The new field consists in a sum of all line items prices without any discount, taxes or shipping rates applications.