### PR TITLE
Fix cart subtotal field

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -96,7 +96,7 @@ export default class Cart extends Component {
       classes: this.classes,
       lineItemsHtml: this.lineItemsHtml,
       isEmpty: this.isEmpty,
-      formattedTotal: this.formattedTotal,
+      formattedTotal: this.formattedLineItemsSubtotal,
       contents: this.options.contents,
       cartNote: this.cartNote,
     });

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -428,7 +428,7 @@ describe('Cart class', () => {
         subtotalPrice: '123.00',
         lineItemsSubtotalPrice: {
           amount: '130.00',
-          currencyCode: 'USD'
+          currencyCode: 'USD',
         },
       };
       cart.lineItemCache = lineItems;
@@ -459,7 +459,7 @@ describe('Cart class', () => {
     });
 
     it('returns an object with formatted total', () => {
-      assert.equal(viewData.formattedTotal, cart.formattedTotal);
+      assert.equal(viewData.formattedTotal, cart.formattedLineItemsSubtotal);
     });
 
     it('returns an object with contents', () => {


### PR DESCRIPTION
Leverage the new `formattedLineItemsSubtotal` getter in the cart's `viewData`