### PR TITLE
Add check for user agent before window.open

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -5,6 +5,7 @@ import Checkout from './checkout';
 import windowUtils from '../utils/window-utils';
 import formatMoney from '../utils/money';
 import normalizeConfig from '../utils/normalize-config';
+import browserFeatures from '../utils/detect-features';
 import ProductView from '../views/product';
 import ProductUpdater from '../updaters/product';
 
@@ -602,7 +603,7 @@ export default class Product extends Component {
       this.props.tracker.track('Direct Checkout', {});
       let checkoutWindow;
 
-      if (this.config.cart.popup) {
+      if (this.config.cart.popup && browserFeatures.windowOpen()) {
         const params = (new Checkout(this.config)).params;
         checkoutWindow = window.open('', 'checkout', params);
       } else {

--- a/src/utils/detect-features.js
+++ b/src/utils/detect-features.js
@@ -32,8 +32,20 @@ var supportsTransforms = function() {
   return detectCSSFeature('transform');
 }
 
+const supportsWindowOpen = () => {
+  const userAgent = navigator.userAgent || navigator.vendor || window.opera;
+  if (userAgent.indexOf('Mac OS X') === -1) {
+    return true;
+  }
+  const unSupportedApps = ['Instagram', 'Pinterest/iOS', 'FBAN/FBIOS', 'FBAN/MessengerForiOS'];
+  return !unSupportedApps.some((appName) => {
+    return userAgent.indexOf(appName) > -1;
+  });
+}
+
 export default {
   animation: supportsAnimations(),
   transition: supportsTransitions(),
   transform: supportsTransforms(),
+  windowOpen: supportsWindowOpen,
 }

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ import './unit/tracker';
 import './unit/merge';
 import './unit/money';
 import './unit/normalize-config';
+import './unit/detect-features';
 
 window.chai = chai;
 window.sinon = sinon;

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -301,13 +301,13 @@ describe('Cart class', () => {
   });
 
   describe('get formattedLineItemsSubtotal', () => {
-    it.only('uses money helper to return currency formatted value', () => {
+    it('uses money helper to return currency formatted value', () => {
       cart.model = {
         lineItemsSubtotalPrice: {
           amount: '30.00',
-          currencyCode: 'USD'
-        }
-      }
+          currencyCode: 'USD',
+        },
+      };
       assert.equal(cart.formattedLineItemsSubtotal, '$30.00');
     });
   });

--- a/test/unit/detect-features.js
+++ b/test/unit/detect-features.js
@@ -1,0 +1,63 @@
+import browserFeatures from '../../src/utils/detect-features';
+
+describe('windowOpen', () => {
+  it('returns true if user agent does not contain `Mac OS X`', () => {
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36';
+    Object.defineProperty(window.navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true,
+    });
+
+    assert.isTrue(browserFeatures.windowOpen());
+  });
+
+  it('returns false if user agent contains `Mac OS X` and `Instagram`', () => {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57 Instagram 85.0.0.10.100 (iPhone10,3; iOS 12_1_4; en_US; en-US; scale=3.00; gamut=wide; 1125x2436; 145918352)';
+    Object.defineProperty(window.navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true,
+    });
+
+    assert.isFalse(browserFeatures.windowOpen());
+  });
+
+  it('returns false if user agent contains `Mac OS X` and `Pinterest/iOS`', () => {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57 [Pinterest/iOS]';
+    Object.defineProperty(window.navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true,
+    });
+
+    assert.isFalse(browserFeatures.windowOpen());
+  });
+
+  it('returns false if user agent contains `Mac OS X` amd `FBAN/FBIOS`', () => {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16D57 [FBAN/FBIOS;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/12.1.4;FBSS/2;FBCR/Verizon;FBID/phone;FBLC/en_US;FBOP/5]';
+    Object.defineProperty(window.navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true,
+    });
+
+    assert.isFalse(browserFeatures.windowOpen());
+  });
+
+  it('returns false if user agent contains `Mac OS X` and `FBAN/MessengerForiOS`', () => {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16C101 [FBAN/MessengerForiOS;FBAV/204.0.0.37.117;FBBV/143733207;FBDV/iPhone10,5;FBMD/iPhone;FBSN/iOS;FBSV/12.1.2;FBSS/3;FBCR/AT&T;FBID/phone;FBLC/en_US;FBOP/5]';
+    Object.defineProperty(window.navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true,
+    });
+
+    assert.isFalse(browserFeatures.windowOpen());
+  });
+
+  it('returns true if user agent contains `Mac OS X` but no unsupported apps', () => {
+    const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1';
+    Object.defineProperty(window.navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true,
+    });
+
+    assert.isTrue(browserFeatures.windowOpen());
+  });
+});


### PR DESCRIPTION
To prevent `window.open` from being called when it is not properly supported by the browser, a new function was added to check for unsupported user agents. 

To 🎩 : 
* Verify that popup functionality in other browsers is supported
- [x] Chrome Mac
- [x] Safari Mac
- [x] Firefox Mac
- [x] Chrome Windows
- [x] Firefox Windows
- [x] Edge Windows
- [x] iOS Safari
- [x] Android chrome
* Verify that direct checkout will open the web checkout on the following iOS in-app browsers: 
- [x] Facebook
- [x] Messenger
- [x] Instagram
- [x] Pinterest