### PR TITLE
Use the global config cart node for product sets

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -106,6 +106,7 @@ export default class ProductSet extends Component {
    */
   init(data) {
     const cartConfig = Object.assign({}, this.globalConfig, {
+      node: this.globalConfig.cartNode,
       options: this.config,
     });
 


### PR DESCRIPTION
Currently, the product set component ignores the `cartNode` set at the global level. Therefore, it is always appending new dom nodes to the document for the cart when initializing a collection buy button.

This PR updates the product set component to pass through the `cartNode` option when creating a cart, like the [product component](https://github.com/Shopify/buy-button-js/blob/master/src/components/product.js#L536). 


To test:
* pass in a reference to a dom node in the config's top level `cartNode` option
* verify that the cart renders inside the node, instead of appending new divs to the document 