### PR TITLE
Update modal of first product in product set

### DIFF
--- a/src/updaters/product-set.js
+++ b/src/updaters/product-set.js
@@ -3,7 +3,13 @@ import Updater from '../updater';
 export default class ProductSetUpdater extends Updater {
   updateConfig(config) {
     super.updateConfig(config);
-    this.component.props.destroyComponent('modal');
+    if (this.component.products[0].modal) {
+      this.component.products[0].modal.updateConfig(Object.assign({}, config, {
+        options: Object.assign({}, config.options, {
+          product: config.options.modalProduct,
+        }),
+      }));
+    }
     this.component.cart.updateConfig(config);
     this.component.renderProducts();
   }

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -239,6 +239,9 @@ describe('ProductSet class', () => {
     beforeEach(() => {
       superSpy = sinon.stub(Updater.prototype, 'updateConfig');
       renderProductsSpy = sinon.stub(set, 'renderProducts');
+      set.products = [{
+        modal: null,
+      }];
       set.cart = {
         updateConfig: sinon.spy()
       }


### PR DESCRIPTION
* Use the same logic as the product component's `updateConfig` to update the modal of the first product in a product set, instead of destroying it