### PR TITLE
update product instead of modal for product set updates

### DIFF
--- a/src/updaters/product-set.js
+++ b/src/updaters/product-set.js
@@ -3,13 +3,9 @@ import Updater from '../updater';
 export default class ProductSetUpdater extends Updater {
   updateConfig(config) {
     super.updateConfig(config);
-    if (this.component.products[0].modal) {
-      this.component.products[0].modal.updateConfig(Object.assign({}, config, {
-        options: Object.assign({}, config.options, {
-          product: config.options.modalProduct,
-        }),
-      }));
-    }
+    this.component.products[0].updateConfig({
+      options: Object.assign({}, config.options),
+    });
     this.component.cart.updateConfig(config);
     this.component.renderProducts();
   }

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -240,7 +240,7 @@ describe('ProductSet class', () => {
       superSpy = sinon.stub(Updater.prototype, 'updateConfig');
       renderProductsSpy = sinon.stub(set, 'renderProducts');
       set.products = [{
-        modal: null,
+        updateConfig: sinon.spy()
       }];
       set.cart = {
         updateConfig: sinon.spy()
@@ -251,9 +251,10 @@ describe('ProductSet class', () => {
       superSpy.restore();
     });
 
-    it('calls updateConfig on cart', () => {
+    it('calls updateConfig on super, cart and first product', () => {
       set.updateConfig(newConfig);
       assert.calledWith(set.cart.updateConfig, newConfig);
+      assert.calledWith(set.products[0].updateConfig, {options: newConfig.options});
       assert.calledWith(superSpy, newConfig);
     });
   });


### PR DESCRIPTION
Instead of updating the first product's modal direct, update the entire product. This enables the product's modal to have the correct styles when it opens, since it pulls from the product directly.