### PR TITLE
Bump js-buy-sdk to v2.7.0 and remove use of deprecated fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "morphdom": "2.5.5",
     "mustache": "3.0.1",
     "node-sass": "4.12.0",
-    "shopify-buy": "2.2.1",
+    "shopify-buy": "2.7.0",
     "uglify-js": "3.6.0"
   }
 }

--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -81,7 +81,7 @@ export default class Cart extends Component {
       data.classes = this.classes;
       data.lineItemImage = this.imageForLineItem(data);
       data.variantTitle = data.variant.title === 'Default Title' ? '' : data.variant.title;
-      data.formattedPrice = formatMoney(data.variant.price * data.quantity, this.moneyFormat);
+      data.formattedPrice = formatMoney(data.variant.priceV2.amount * data.quantity, this.moneyFormat);
       return acc + this.childTemplate.render({data}, (output) => `<div id="${lineItem.id}" class=${this.classes.lineItem.lineItem}>${output}</div>`);
     }, '');
   }
@@ -381,10 +381,10 @@ export default class Cart extends Component {
    */
   cartItemTrackingInfo(item, quantity) {
     return {
-      id: item.variant_id,
+      id: item.variant.id,
       name: item.title,
       sku: null,
-      price: item.price,
+      price: item.variant.priceV2.amount,
       prevQuantity: item.quantity,
       quantity: parseFloat(quantity),
     };

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -87,7 +87,7 @@ export default class ProductSet extends Component {
         return {
           id: product.id,
           name: product.selectedVariant.title,
-          price: product.selectedVariant.price,
+          price: product.selectedVariant.priceV2.amount,
           sku: null,
         };
       });

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -177,7 +177,7 @@ export default class Product extends Component {
     if (!this.selectedVariant) {
       return '';
     }
-    return formatMoney(this.selectedVariant.price, this.globalConfig.moneyFormat);
+    return formatMoney(this.selectedVariant.priceV2.amount, this.globalConfig.moneyFormat);
   }
 
   /**
@@ -185,10 +185,10 @@ export default class Product extends Component {
    * @return {String}
    */
   get formattedCompareAtPrice() {
-    if (!this.selectedVariant) {
+    if (!this.selectedVariant || !this.selectedVariant.compareAtPriceV2) {
       return '';
     }
-    return formatMoney(this.selectedVariant.compareAtPrice, this.globalConfig.moneyFormat);
+    return formatMoney(this.selectedVariant.compareAtPriceV2.amount, this.globalConfig.moneyFormat);
   }
 
   /**
@@ -289,7 +289,7 @@ export default class Product extends Component {
   }
 
   get priceClass() {
-    return this.selectedVariant && this.selectedVariant.compareAtPrice ? this.classes.product.loweredPrice : '';
+    return this.selectedVariant && this.selectedVariant.compareAtPriceV2 ? this.classes.product.loweredPrice : '';
   }
 
   get isButton() {
@@ -429,7 +429,7 @@ export default class Product extends Component {
         id: this.id,
         name: this.selectedVariant.productTitle,
         sku: null,
-        price: this.selectedVariant.price,
+        price: this.selectedVariant.priceV2.amount,
       });
     }
 
@@ -447,7 +447,7 @@ export default class Product extends Component {
       name: variant.productTitle,
       quantity: this.selectedQuantity,
       sku: null,
-      price: variant.price,
+      price: variant.priceV2.amount,
     };
   }
 

--- a/test/fixtures/product-fixture.js
+++ b/test/fixtures/product-fixture.js
@@ -43,6 +43,10 @@ const testProduct = {
       id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==',
       productId: 123,
       price: '123.00',
+      priceV2: {
+        amount: '123.00',
+        currencyCode: 'CAD',
+      },
       title: 'sloth / small',
       available: true,
       image: {
@@ -64,6 +68,10 @@ const testProduct = {
       id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0Ng==',
       productId: 123,
       price: '1.00',
+      priceV2: {
+        amount: '1.00',
+        currencyCode: 'CAD',
+      },
       title: 'shark / small',
       available: true,
       image: {
@@ -85,6 +93,10 @@ const testProduct = {
       id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0Nw==',
       productId: 123,
       price: '999.99',
+      priceV2: {
+        amount: '999.99',
+        currencyCode: 'CAD',
+      },
       title: 'shark / large',
       available: true,
       image: {
@@ -106,6 +118,10 @@ const testProduct = {
       id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0OA==',
       productId: 123,
       price: '0.00',
+      priceV2: {
+        amount: '0.00',
+        currencyCode: 'CAD',
+      },
       title: 'cat / small',
       available: false,
       selectedOptions: [

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -84,7 +84,15 @@ describe('Cart class', () => {
           variant_title: 'test2',
           line_price: 20,
           quantity: 1,
-          variant: {image: {src: 'cdn.shopify.com/image.jpg'}},
+          variant: {
+            image: {
+              src: 'cdn.shopify.com/image.jpg'
+            },
+            priceV2:{
+              amount: '5.00',
+              currencyCode: 'CAD',
+            },
+          },
         }
       ]
 
@@ -237,7 +245,13 @@ describe('Cart class', () => {
       cart.model = {
         lineItems: [{
           id: 1234,
-          quantity: 1
+          quantity: 1,
+          variant: {
+            priceV2: {
+              amount: '10.00',
+              currencyCode: 'CAD',
+            },
+          },
         }],
       }
       cart.updateItem = sinon.spy();
@@ -417,7 +431,10 @@ describe('Cart class', () => {
           variant: {
             id: 1111,
             title: 'test variant',
-            price: '20.00',
+            priceV2: {
+              amount: '20.00',
+              currencyCode: 'CAD',
+            },
           },
         },
       ];

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1334,26 +1334,41 @@ describe('Product Component class', () => {
           });
 
           it('returns formatted money with selected variant price and money format from global config if there is a selected variant', () => {
-            product.selectedVariant = {price: 5};
+            product.selectedVariant = {
+              priceV2: {
+                amount: '5.00',
+                currencyCode: 'CAD',
+              },
+            };
             product.globalConfig = {moneyFormat: 'CAD'};
             assert.equal(product.formattedPrice, formattedMoney);
             assert.calledOnce(formatMoneyStub);
-            assert.calledWith(formatMoneyStub, product.selectedVariant.price, product.globalConfig.moneyFormat);
+            assert.calledWith(formatMoneyStub, product.selectedVariant.priceV2.amount, product.globalConfig.moneyFormat);
           });
         });
 
         describe('formattedCompareAtPrice', () => {
           it('returns empty string if there is no selected variant', () => {
             product.selectedVariant = null;
-            assert.equal(product.formattedPrice, '');
+            assert.equal(product.formattedCompareAtPrice, '');
+          });
+
+          it('returns empty string if there is no compare at price', () => {
+            product.selectedVariant.compareAtPriceV2 = null;
+            assert.equal(product.formattedCompareAtPrice, '');
           });
 
           it('returns formatted money with selected variant compare at price and money format from global config if there is a selected variant', () => {
-            product.selectedVariant = {compareAtPrice: 5};
+            product.selectedVariant = {
+              compareAtPriceV2: {
+                amount: '5.00',
+                currencyCode: 'CAD',
+              },
+            };
             product.globalConfig = {moneyFormat: 'CAD'};
-            assert.equal(product.formattedPrice, formattedMoney);
+            assert.equal(product.formattedCompareAtPrice, formattedMoney);
             assert.calledOnce(formatMoneyStub);
-            assert.calledWith(formatMoneyStub, product.selectedVariant.price, product.globalConfig.moneyFormat);
+            assert.calledWith(formatMoneyStub, product.selectedVariant.compareAtPriceV2.amount, product.globalConfig.moneyFormat);
           });
         });
       });
@@ -1799,12 +1814,17 @@ describe('Product Component class', () => {
               },
             },
           });
-          product.selectedVariant = {compareAtPrice: '$5.00'};
+          product.selectedVariant = {
+            compareAtPriceV2: {
+              amount: '5.00',
+              currencyCode: 'CAD',
+            },
+          };
           assert.equal(product.priceClass, product.classes.product.loweredPrice);
         });
 
         it('returns empty string if selected variant does not have a compare at price', () => {
-          product.selectedVariant = {compareAtPrice: null};
+          product.selectedVariant = {compareAtPriceV2: null};
           assert.equal(product.priceClass, '');
         });
       });
@@ -2206,14 +2226,17 @@ describe('Product Component class', () => {
         it('returns an object with button destination, id, name, sku, and price if selected variant exists', () => {
           product.selectedVariant = {
             productTitle: 'hat',
-            price: '$5.00',
+            priceV2: {
+              amount: '5.00',
+              currencyCode: 'CAD',
+            },
           };
           const expectedObject = {
             destination: product.options.buttonDestination,
             id: product.id,
             name: product.selectedVariant.productTitle,
             sku: null,
-            price: product.selectedVariant.price,
+            price: product.selectedVariant.priceV2.amount,
           };
           assert.deepEqual(product.trackingInfo, expectedObject);
         });
@@ -2224,7 +2247,10 @@ describe('Product Component class', () => {
           product.selectedVariant = {
             id: '456',
             productTitle: 'hat',
-            price: '$5.00',
+            priceV2: {
+              amount: '5.00',
+              currencyCode: 'CAD',
+            },
           };
           product.selectedQuantity = 5;
           const expectedObject = {
@@ -2232,7 +2258,7 @@ describe('Product Component class', () => {
             name: product.selectedVariant.productTitle,
             quantity: product.selectedQuantity,
             sku: null,
-            price: product.selectedVariant.price,
+            price: product.selectedVariant.priceV2.amount,
           };
           assert.deepEqual(product.selectedVariantTrackingInfo, expectedObject);
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6415,10 +6415,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.2.1.tgz#c4634d47dcf81cf9815bcae70419c048672f3206"
-  integrity sha512-51+9oFZJXSPJ1dsqhrEyYb1n0E1LzPlvvKA+nvY8YM7ogprZmGTzU1CYoqnJHUs+BLnPGGrtZVubT9ZoAg1C2Q==
+shopify-buy@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.7.0.tgz#2a37e01bb3639fce1a882671349275039dfab830"
+  integrity sha512-LexWoBdBbnxu1urStQn8MAEgwj/AKGOEjHuUd0hRtCSSg6Q6/QzEAd0IQKgWC29Nn7sgyxatZd+xqS8mh0QmdA==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
* Bump js-buy-sdk to v2.7.0, which brings in MoneyV2 fields on the product variant
* Replace use of deprecated fields with `priceV2` and `compareAtPriceV2` 
* Update tests

Tested on Chrome, Safari, Firefox, Opera, Edge, IE10, IE11, Safari iOS