### PR TITLE
Add missing double quotes around classes

### DIFF
--- a/src/templates/option.js
+++ b/src/templates/option.js
@@ -1,5 +1,5 @@
 const optionTemplates = {
-  option: `<div class={{data.classes.option.option}} data-element="option.option">
+  option: `<div class="{{data.classes.option.option}}" data-element="option.option">
     <label class="{{data.classes.option.label}} {{#data.onlyOption}}{{data.classes.option.hiddenLabel}}{{/data.onlyOption}}" data-element="option.label">{{data.name}}</label>
       <div class="{{data.classes.option.wrapper}}" data-element="option.wrapper">
       <select class="{{data.classes.option.select}}" name="{{data.name}}" data-element="option.select">


### PR DESCRIPTION
Add the missing double quotes around options classes.

Fixes: https://github.com/Shopify/buy-button-js/issues/578