### PR TITLE
Only show product set pagination if contents option is true

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -218,7 +218,9 @@ export default class ProductSet extends Component {
 
     return Promise.all(promises).then(() => {
       this.view.resizeUntilFits();
-      this.showPagination();
+      if (this.options.contents.pagination) {
+        this.showPagination();
+      }
       return this;
     });
   }

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -206,18 +206,34 @@ describe('ProductSet class', () => {
     beforeEach(() => {
       initSpy = sinon.spy(Product.prototype, 'init');
       showPaginationStub = sinon.stub(set, 'showPagination').returns(Promise.resolve());
+      set.model.products = [fakeProduct];
       set.view.render();
     });
 
     afterEach(() => {
       initSpy.restore();
+      showPaginationStub.restore();
     });
 
     it('initializes an array of products', () => {
-      set.model.products = [fakeProduct];
-
-      return set.renderProducts().then((data) => {
+      return set.renderProducts().then(() => {
         assert.calledWith(initSpy, fakeProduct);
+      });
+    });
+
+    it('calls showPagination if pagination is set to true in contents', () => {
+      set.config.productSet.contents.pagination = true;
+
+      return set.renderProducts().then(() => {
+        assert.calledOnce(showPaginationStub);
+      });
+    });
+
+    it('does not call showPagination if pagination is set to false in contents', () => {
+      set.config.productSet.contents.pagination = false;
+
+      return set.renderProducts().then(() => {
+        assert.notCalled(showPaginationStub);
       });
     });
   });


### PR DESCRIPTION
Only call `showPagination` if the pagination contents option is true

Closes #454 

To test:
* Set the product set pagination contents option to false
  * Verify there are no console errors and the pagination button does not render 
* Set the product set pagination contents option to true
  * Verify that the pagination button renders, and pagination is functional 