### PR TITLE
Fix pagination error and update tracking info

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -432,11 +432,13 @@ export default class Cart extends Component {
   cartItemTrackingInfo(item, quantity) {
     return {
       id: item.variant.id,
+      variantName: item.variant.title,
+      productId: item.variant.product.id,
       name: item.title,
-      sku: null,
       price: item.variant.priceV2.amount,
       prevQuantity: item.quantity,
       quantity: parseFloat(quantity),
+      sku: null,
     };
   }
 }

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -86,8 +86,8 @@ export default class ProductSet extends Component {
       return this.model.products.map((product) => {
         return {
           id: product.id,
-          name: product.selectedVariant.title,
-          price: product.selectedVariant.priceV2.amount,
+          name: product.variants[0].title,
+          price: product.variants[0].priceV2.amount,
           sku: null,
         };
       });
@@ -218,9 +218,12 @@ export default class ProductSet extends Component {
 
     return Promise.all(promises).then(() => {
       this.view.resizeUntilFits();
-      if (this.options.contents.pagination) {
+      const hasPagination = Object.keys(this.model.products[0]).includes('hasNextPage');
+
+      if (this.options.contents.pagination && hasPagination) {
         this.showPagination();
       }
+
       return this;
     });
   }

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -218,7 +218,7 @@ export default class ProductSet extends Component {
 
     return Promise.all(promises).then(() => {
       this.view.resizeUntilFits();
-      const hasPagination = Object.keys(this.model.products[0]).includes('hasNextPage');
+      const hasPagination = (Object.keys(this.model.products[0]).indexOf('hasNextPage') > -1);
 
       if (this.options.contents.pagination && hasPagination) {
         this.showPagination();

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -82,18 +82,26 @@ export default class ProductSet extends Component {
    * @return {Object|Array}
    */
   get trackingInfo() {
+    const destination = this.config.product.buttonDestination;
+
     if (isArray(this.id)) {
       return this.model.products.map((product) => {
+        const variant = product.variants[0];
         return {
           id: product.id,
-          name: product.variants[0].title,
-          price: product.variants[0].priceV2.amount,
+          name: product.title,
+          variantId: variant.id,
+          variantName: variant.title,
+          price: variant.priceV2.amount,
+          destination,
           sku: null,
         };
       });
     }
+
     return {
       id: this.id,
+      destination,
     };
   }
 

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -82,27 +82,33 @@ export default class ProductSet extends Component {
    * @return {Object|Array}
    */
   get trackingInfo() {
-    const destination = this.config.product.buttonDestination;
+    const contents = this.config.product.contents;
+    const contentString = Object.keys(contents).filter((key) => contents[key]).toString();
+
+    const config = {
+      destination: this.config.product.buttonDestination,
+      layout: this.config.product.layout,
+      contents: contentString,
+      checkoutPopup: this.config.cart.popup,
+    };
 
     if (isArray(this.id)) {
       return this.model.products.map((product) => {
         const variant = product.variants[0];
-        return {
+        return Object.assign(config, {
           id: product.id,
           name: product.title,
           variantId: variant.id,
           variantName: variant.title,
           price: variant.priceV2.amount,
-          destination,
           sku: null,
-        };
+        });
       });
     }
 
-    return {
-      id: this.id,
-      destination,
-    };
+    return Object.assign(config, {
+      id: this.storefrontId,
+    });
   }
 
   /**
@@ -226,7 +232,7 @@ export default class ProductSet extends Component {
 
     return Promise.all(promises).then(() => {
       this.view.resizeUntilFits();
-      const hasPagination = (Object.keys(this.model.products[0]).indexOf('hasNextPage') > -1);
+      const hasPagination = this.model.products[0].hasOwnProperty('hasNextPage');
 
       if (this.options.contents.pagination && hasPagination) {
         this.showPagination();

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -420,20 +420,17 @@ export default class Product extends Component {
    * @return {Object}
    */
   get trackingInfo() {
-    const info = {
+    const variant = this.selectedVariant || this.model.variants[0];
+
+    return {
+      id: this.model.id,
+      name: this.model.title,
+      variantId: variant.id,
+      variantName: variant.title,
+      price: variant.priceV2.amount,
       destination: this.options.buttonDestination,
+      sku: null,
     };
-
-    if (this.selectedVariant) {
-      Object.assign(info, {
-        id: this.id,
-        name: this.selectedVariant.productTitle,
-        sku: null,
-        price: this.selectedVariant.priceV2.amount,
-      });
-    }
-
-    return info;
   }
 
   /**
@@ -444,10 +441,12 @@ export default class Product extends Component {
     const variant = this.selectedVariant;
     return {
       id: variant.id,
-      name: variant.productTitle,
+      name: variant.title,
+      productId: this.model.id,
+      productName: this.model.title,
       quantity: this.selectedQuantity,
-      sku: null,
       price: variant.priceV2.amount,
+      sku: null,
     };
   }
 

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -421,6 +421,8 @@ export default class Product extends Component {
    */
   get trackingInfo() {
     const variant = this.selectedVariant || this.model.variants[0];
+    const contents = this.options.contents;
+    const contentString = Object.keys(contents).filter((key) => contents[key]).toString();
 
     return {
       id: this.model.id,
@@ -429,6 +431,9 @@ export default class Product extends Component {
       variantName: variant.title,
       price: variant.priceV2.amount,
       destination: this.options.buttonDestination,
+      layout: this.options.layout,
+      contents: contentString,
+      checkoutPopup: this.config.cart.popup,
       sku: null,
     };
   }

--- a/src/utils/track.js
+++ b/src/utils/track.js
@@ -28,7 +28,7 @@ export default class Tracker {
         if (properties.prevQuantity && (properties.quantity < properties.prevQuantity)) {
           return;
         }
-        this.track('Added Product', properties);
+        return this.track('Added Product', properties);
       default:
         return this.track(eventName, properties);
     }

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -498,6 +498,7 @@ describe('Cart class', () => {
         }],
       }
       cart.updateItem = sinon.spy();
+      cart.cartItemTrackingInfo = sinon.spy();
     });
 
     it('calls updateItem', () => {
@@ -954,6 +955,38 @@ describe('Cart class', () => {
       assert.deepEqual(discounts[0], {
         text: discountTitle,
         amount: `-$${discountPercentage / 100 * lineItemSubtotal}.00`,
+      });
+    });
+  });
+
+  describe('cartItemTrackingInfo', () => {
+    it('returns tracking info for cart item', () => {
+      const item = {
+        title: 'Test Sunglasses',
+        quantity: 2,
+        variant: {
+          id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzE5MzE1MjQzMDkwNDg',
+          title: 'Black shades',
+          priceV2: {
+            amount: '50.0',
+          },
+          product: {
+            id: 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xOTQ2Nzc3MjkxOTg2NA',
+          },
+        },
+      };
+
+      const trackingInfo = cart.cartItemTrackingInfo(item, '5');
+
+      assert.deepEqual(trackingInfo, {
+        id: item.variant.id,
+        variantName: item.variant.title,
+        productId: item.variant.product.id,
+        name: item.title,
+        price: item.variant.priceV2.amount,
+        prevQuantity: item.quantity,
+        quantity: 5,
+        sku: null,
       });
     });
   });

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -6,7 +6,7 @@ import testProduct from '../fixtures/product-fixture';
 import ShopifyBuy from '../../src/buybutton';
 
 const config = {
-  id: 'Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzEyMzQ1',
+  storefrontId: 'Z2lkOi8vc2hvcGlmeS9Db2xsZWN0aW9uLzEyMzQ1',
   options: {
     product: {
       templates: {
@@ -14,10 +14,7 @@ const config = {
       }
     }
   },
-  product: {
-    buttonDestination: 'cart',
-  },
-}
+};
 
 const fakeProduct = testProduct;
 
@@ -330,12 +327,20 @@ describe('ProductSet class', () => {
   });
 
   describe('trackingInfo', () => {
+    let expectedContentString;
+
+    beforeEach(() => {
+      expectedContentString = Object.keys(set.config.product.contents).filter((key) => set.config.product.contents[key]).toString();
+    });
 
     it('returns an object with the collection id and button destination when an the product set id is not an array', () => {
       const info = set.trackingInfo;
       assert.deepEqual(info, {
-        id: config.id,
-        destination: config.product.buttonDestination,
+        id: config.storefrontId,
+        destination: set.config.product.buttonDestination,
+        layout: set.config.product.layout,
+        contents: expectedContentString,
+        checkoutPopup: set.config.cart.popup,
       });
     });
 
@@ -349,7 +354,10 @@ describe('ProductSet class', () => {
         variantId: fakeProduct.variants[0].id,
         variantName: fakeProduct.variants[0].title,
         price: fakeProduct.variants[0].priceV2.amount,
-        destination: config.product.buttonDestination,
+        destination: set.config.product.buttonDestination,
+        layout: set.config.product.layout,
+        contents: expectedContentString,
+        checkoutPopup: set.config.cart.popup,
         sku: null,
       }]);
     });

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -221,15 +221,37 @@ describe('ProductSet class', () => {
       });
     });
 
-    it('calls showPagination if pagination is set to true in contents', () => {
+    it('calls showPagination if pagination is set to true in contents and products have connections', () => {
       set.config.productSet.contents.pagination = true;
+      const updatedFakeProduct = Object.assign({}, fakeProduct);
+      updatedFakeProduct.hasNextPage = true;
+      set.model.products = [updatedFakeProduct];
 
       return set.renderProducts().then(() => {
         assert.calledOnce(showPaginationStub);
       });
     });
 
-    it('does not call showPagination if pagination is set to false in contents', () => {
+    it('does not call showPagination if pagination is set to true in contents and products do not have connections', () => {
+      set.config.productSet.contents.pagination = true;
+
+      return set.renderProducts().then(() => {
+        assert.notCalled(showPaginationStub);
+      });
+    });
+
+    it('does not call showPagination if pagination is set to false in contents and products have connections', () => {
+      set.config.productSet.contents.pagination = false;
+      const updatedFakeProduct = Object.assign({}, fakeProduct);
+      updatedFakeProduct.hasNextPage = true;
+      set.model.products = [updatedFakeProduct];
+
+      return set.renderProducts().then(() => {
+        assert.notCalled(showPaginationStub);
+      });
+    });
+
+    it('does not call showPagination if pagination is set to false in contents and products do not have connections', () => {
       set.config.productSet.contents.pagination = false;
 
       return set.renderProducts().then(() => {
@@ -303,4 +325,27 @@ describe('ProductSet class', () => {
       });
     });
   });
+
+  describe('trackingInfo', () => {
+
+    it('returns an object with the collection id when an the product set id is not an array', () => {
+      set.id = 1234;
+      const info = set.trackingInfo;
+      assert.deepEqual(info, {id: 1234});
+    });
+
+    it('returns an array of product info objects when the product set id is an array of ids', () => {
+      set.id = [1234];
+      set.model.products = [fakeProduct];
+      const info = set.trackingInfo;
+      assert.deepEqual(info, [{
+        id: fakeProduct.id,
+        name: fakeProduct.variants[0].title,
+        price: fakeProduct.variants[0].priceV2.amount,
+        sku: null,
+      }]);
+    });
+  });
+
+
 });

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -13,7 +13,10 @@ const config = {
         button: '<button id="button" class="button">Fake button</button>'
       }
     }
-  }
+  },
+  product: {
+    buttonDestination: 'cart',
+  },
 }
 
 const fakeProduct = testProduct;
@@ -328,10 +331,12 @@ describe('ProductSet class', () => {
 
   describe('trackingInfo', () => {
 
-    it('returns an object with the collection id when an the product set id is not an array', () => {
-      set.id = 1234;
+    it('returns an object with the collection id and button destination when an the product set id is not an array', () => {
       const info = set.trackingInfo;
-      assert.deepEqual(info, {id: 1234});
+      assert.deepEqual(info, {
+        id: config.id,
+        destination: config.product.buttonDestination,
+      });
     });
 
     it('returns an array of product info objects when the product set id is an array of ids', () => {
@@ -340,8 +345,11 @@ describe('ProductSet class', () => {
       const info = set.trackingInfo;
       assert.deepEqual(info, [{
         id: fakeProduct.id,
-        name: fakeProduct.variants[0].title,
+        name: fakeProduct.title,
+        variantId: fakeProduct.variants[0].id,
+        variantName: fakeProduct.variants[0].title,
         price: fakeProduct.variants[0].priceV2.amount,
+        destination: config.product.buttonDestination,
         sku: null,
       }]);
     });

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -2213,40 +2213,59 @@ describe('Product Component class', () => {
       describe('trackingInfo', () => {
         beforeEach(() => {
           product.config.product.buttonDestination = 'cart';
+          product.model.variants = [
+            {
+              id: 'Xkdljlejkskskl3Zsike',
+              title: 'variant 1',
+              priceV2: {
+                amount: '6.0',
+              },
+            },
+          ];
         });
 
-        it('returns an object with button destination if there is no selected variant', () => {
+        it('returns a tracking info object with first variant\'s info if there is no selected variant', () => {
           product.selectedVariant = null;
           const expectedObject = {
+            id: product.model.id,
+            name: product.model.title,
+            variantId: product.model.variants[0].id,
+            variantName: product.model.variants[0].title,
+            price: product.model.variants[0].priceV2.amount,
             destination: product.options.buttonDestination,
+            sku: null,
           };
+
           assert.deepEqual(product.trackingInfo, expectedObject);
         });
 
-        it('returns an object with button destination, id, name, sku, and price if selected variant exists', () => {
+        it('returns a tracking info object with the selected variant\'s info if selected variant exists', () => {
           product.selectedVariant = {
-            productTitle: 'hat',
+            title: 'hat',
+            id: 'AAkdlfjljwijk3j35j3ljksLqQkslj',
             priceV2: {
               amount: '5.00',
               currencyCode: 'CAD',
             },
           };
           const expectedObject = {
-            destination: product.options.buttonDestination,
-            id: product.id,
-            name: product.selectedVariant.productTitle,
-            sku: null,
+            id: product.model.id,
+            name: product.model.title,
+            variantId: product.selectedVariant.id,
+            variantName: product.selectedVariant.title,
             price: product.selectedVariant.priceV2.amount,
+            destination: product.options.buttonDestination,
+            sku: null,
           };
           assert.deepEqual(product.trackingInfo, expectedObject);
         });
       });
 
       describe('selectedVariantTrackingInfo', () => {
-        it('returns an object with selected variant id, name, quantity, sku, and price', () => {
+        it('returns a tracking info object with selected variant info', () => {
           product.selectedVariant = {
             id: '456',
-            productTitle: 'hat',
+            title: 'hat',
             priceV2: {
               amount: '5.00',
               currencyCode: 'CAD',
@@ -2255,7 +2274,9 @@ describe('Product Component class', () => {
           product.selectedQuantity = 5;
           const expectedObject = {
             id: product.selectedVariant.id,
-            name: product.selectedVariant.productTitle,
+            name: product.selectedVariant.title,
+            productId: product.model.id,
+            productName: product.model.title,
             quantity: product.selectedQuantity,
             sku: null,
             price: product.selectedVariant.priceV2.amount,

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -2211,6 +2211,8 @@ describe('Product Component class', () => {
       });
 
       describe('trackingInfo', () => {
+        let expectedContentString;
+
         beforeEach(() => {
           product.config.product.buttonDestination = 'cart';
           product.model.variants = [
@@ -2222,10 +2224,12 @@ describe('Product Component class', () => {
               },
             },
           ];
+          expectedContentString = Object.keys(product.options.contents).filter((key) => product.options.contents[key]).toString();
         });
 
         it('returns a tracking info object with first variant\'s info if there is no selected variant', () => {
           product.selectedVariant = null;
+
           const expectedObject = {
             id: product.model.id,
             name: product.model.title,
@@ -2233,6 +2237,9 @@ describe('Product Component class', () => {
             variantName: product.model.variants[0].title,
             price: product.model.variants[0].priceV2.amount,
             destination: product.options.buttonDestination,
+            layout: product.options.layout,
+            contents: expectedContentString,
+            checkoutPopup: product.config.cart.popup,
             sku: null,
           };
 
@@ -2255,6 +2262,9 @@ describe('Product Component class', () => {
             variantName: product.selectedVariant.title,
             price: product.selectedVariant.priceV2.amount,
             destination: product.options.buttonDestination,
+            layout: product.options.layout,
+            contents: expectedContentString,
+            checkoutPopup: product.config.cart.popup,
             sku: null,
           };
           assert.deepEqual(product.trackingInfo, expectedObject);


### PR DESCRIPTION
Currently, when a product set is initialized (i.e. an array of product ids), there is a pagination console error (since product sets do not have connections, it cannot be paginated). This PR fixes this issue by only showing pagination for `collections` and not `product sets`.

Also, the tracking info objects passed to the `tracker` are outdated and some properties are incorrect - this PR will update the tracking info and will also standardize the `id` property to always return the `storefrontId`.

🎩 instructions:
- load a product set buy button and ensure that there are no pagination console error and pagination does not appear in the UI
- load a collection buy button and ensure that pagination is still available and works as expected