### PR TITLE
Add missing userEvent 'openCheckout'

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -306,6 +306,7 @@ export default class Cart extends Component {
   }
 
   onCheckout() {
+    this._userEvent('openCheckout');
     this.checkout.open(this.model.webUrl);
   }
 


### PR DESCRIPTION
This PR adds the missing userEvent 'openCheckout' to the onCheckout() function, restoring expected functionality as per the docs: https://shopify.github.io/buy-button-js/customization/#cart-events.

Credit to @hamisor for the fix, this is simply an updated version of #375 with conflicts resolved and style consistent.