### PR TITLE
Add new tracking events

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -307,6 +307,7 @@ export default class Cart extends Component {
 
   onCheckout() {
     this._userEvent('openCheckout');
+    this.props.tracker.track('Open cart checkout', {});
     this.checkout.open(this.model.webUrl);
   }
 

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -102,6 +102,7 @@ export default class ProductSet extends Component {
           variantName: variant.title,
           price: variant.priceV2.amount,
           sku: null,
+          isProductSet: true,
         });
       });
     }

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -456,6 +456,16 @@ export default class Product extends Component {
   }
 
   /**
+   * get info about product to be sent to tracker
+   * @return {Object}
+   */
+  get productTrackingInfo() {
+    return {
+      id: this.model.id,
+    };
+  }
+
+  /**
    * get configuration object for product details modal based on product config and modalProduct config.
    * @return {Object} configuration object.
    */
@@ -599,6 +609,7 @@ export default class Product extends Component {
       }
     } else if (this.options.buttonDestination === 'modal') {
       this.props.setActiveEl(target);
+      this.props.tracker.track('Open modal', this.productTrackingInfo);
       this.openModal();
     } else if (this.options.buttonDestination === 'onlineStore') {
       this.openOnlineStore();

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -14,9 +14,12 @@ let cart;
 describe('Cart class', () => {
   const moneyFormat = '${{amount}}';
   let closeCartSpy;
+  let trackSpy;
 
   beforeEach(() => {
     closeCartSpy = sinon.spy();
+    trackSpy = sinon.spy();
+
     cart = new Cart({
       options: {
         cart: {
@@ -44,12 +47,14 @@ describe('Cart class', () => {
         trackMethod: (fn) => {
           return function () {
             fn(...arguments);
-          }
-        }
+          };
+        },
+        track: trackSpy,
       },
       closeCart: closeCartSpy,
     });
   });
+
   afterEach(() => {
     cart.destroy();
   });
@@ -769,6 +774,37 @@ describe('Cart class', () => {
 
     it('returns an object with cart note', () => {
       assert.equal(viewData.cartNote, cart.cartNote);
+    });
+  });
+
+  describe('onCheckout()', () => {
+    let openCheckoutStub;
+    let userEventStub;
+
+    beforeEach(() => {
+      openCheckoutStub = sinon.stub(cart.checkout, 'open');
+      userEventStub = sinon.stub(cart, '_userEvent');
+      cart.onCheckout();
+    });
+
+    afterEach(() => {
+      openCheckoutStub.restore();
+      userEventStub.restore();
+    });
+
+    it('triggers open checkout user event', () => {
+      assert.calledOnce(userEventStub);
+      assert.calledWith(userEventStub, 'openCheckout');
+    });
+
+    it('tracks open checkout', () => {
+      assert.calledOnce(trackSpy);
+      assert.calledWith(trackSpy, 'Open cart checkout', {});
+    });
+
+    it('open checkout', () => {
+      assert.calledOnce(openCheckoutStub);
+      assert.calledWith(openCheckoutStub, cart.model.webUrl);
     });
   });
 

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -359,6 +359,7 @@ describe('ProductSet class', () => {
         contents: expectedContentString,
         checkoutPopup: set.config.cart.popup,
         sku: null,
+        isProductSet: true,
       }]);
     });
   });

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -524,6 +524,11 @@ describe('Product Component class', () => {
           assert.calledWith(setActiveElSpy, target);
         });
 
+        it('tracks open modal', () => {
+          assert.calledOnce(trackSpy);
+          assert.calledWith(trackSpy, 'Open modal', product.productTrackingInfo);
+        });
+
         it('opens modal', () => {
           assert.calledOnce(openModalStub);
         });
@@ -2215,6 +2220,7 @@ describe('Product Component class', () => {
 
         beforeEach(() => {
           product.config.product.buttonDestination = 'cart';
+          product.model.id = 'lakjjk3ls3546lslsdkjf==';
           product.model.variants = [
             {
               id: 'Xkdljlejkskskl3Zsike',
@@ -2292,6 +2298,19 @@ describe('Product Component class', () => {
             price: product.selectedVariant.priceV2.amount,
           };
           assert.deepEqual(product.selectedVariantTrackingInfo, expectedObject);
+        });
+      });
+
+      describe('productTrackingInfo', () => {
+        beforeEach(() => {
+          product.model.id = 'Xkldjfjkej3l4jl3j5ljsodjflll';
+        });
+
+        it('returns a tracking info object with product id', () => {
+          const expectedObject = {
+            id: product.model.id,
+          };
+          assert.deepEqual(product.productTrackingInfo, expectedObject);
         });
       });
 


### PR DESCRIPTION
Add 2 new tracking events:
- `Open cart checkout` event: triggers when a user clicks on the checkout button from the cart
- `Open modal` event: triggers when a user clicks on the view product details button

Also, the product set tracking info was updated to contain a new `isProductSet` flag.