### PR TITLE
Fix text rendering bug in safari 13

### DIFF
--- a/src/styles/embeds/sass/initializers.css
+++ b/src/styles/embeds/sass/initializers.css
@@ -22,6 +22,10 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
+select {
+  text-rendering: auto !important;
+}
+
 ul {
   list-style: none;
   padding-left: 0;


### PR DESCRIPTION
* Set `text-rendering` to auto to prevent safari from crashing when a select is clicked

To 🎩 : 
* For a product with multiple variants, verify that the selects can be used in safari 13
* Check that selects still work in other browsers