### PR TITLE
Fix a broken link

### DIFF
--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -99,7 +99,7 @@ var text = {
 
 **Type**: object
 
-**Default value**: dependent on component. [View component defaults](https://github.com/Shopify/buy-button-js/blob/master/src/defaults/components.j)
+**Default value**: dependent on component. [View component defaults](https://github.com/Shopify/buy-button-js/blob/master/src/defaults/components.js)
 
 ### `styles`
 


### PR DESCRIPTION
### Description

This is just a quick update to one of the docs! One of the links was giving a 404 because the extension was misspelled.