### PR TITLE
Defer checkout creation to when variants are added to cart

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -624,12 +624,17 @@ export default class Product extends Component {
       } else {
         checkoutWindow = window;
       }
+      const input = {
+        lineItems: [
+          {
+            variantId: this.selectedVariant.id,
+            quantity: this.selectedQuantity,
+          },
+        ],
+      };
 
-      this.props.client.checkout.create().then((checkout) => {
-        const lineItem = {variantId: this.selectedVariant.id, quantity: this.selectedQuantity};
-        this.props.client.checkout.addLineItems(checkout.id, [lineItem]).then((updatedCheckout) => {
-          checkoutWindow.location = updatedCheckout.webUrl;
-        });
+      this.props.client.checkout.create(input).then((checkout) => {
+        checkoutWindow.location = checkout.webUrl;
       });
     }
   }

--- a/src/components/toggle.js
+++ b/src/components/toggle.js
@@ -12,6 +12,9 @@ export default class CartToggle extends Component {
   }
 
   get count() {
+    if (!this.props.cart.model) {
+      return 0;
+    }
     return this.props.cart.model.lineItems.reduce((acc, lineItem) => {
       return acc + lineItem.quantity;
     }, 0);

--- a/test/unit/toggle/toggle-component.js
+++ b/test/unit/toggle/toggle-component.js
@@ -94,6 +94,13 @@ describe('Toggle Component class', () => {
         it('returns the total quantity of all line items in cart model', () => {
           assert.equal(toggle.count, 3);
         });
+
+        it('returns a count of zero if the cart model is null', () => {
+          cart.model = null;
+          const nullCartToggle = new Toggle({node}, {cart});
+
+          assert.equal(toggle.count, 0);
+        });
       });
 
       describe('viewData', () => {


### PR DESCRIPTION
* Reconfigure cart component to only create a checkout when an item is added to cart
* Add additional checks when accessing data from the cart model, since it won't always be defined