### PR TITLE
Prevent API call when storefrontId is an empty array

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -570,9 +570,9 @@ export default class Product extends Component {
    * @return {Promise} promise resolving to model data.
    */
   sdkFetch() {
-    if (this.storefrontId && Array.isArray(this.storefrontId)) {
+    if (this.storefrontId && Array.isArray(this.storefrontId) && this.storefrontId[0]) {
       return this.props.client.product.fetch(this.storefrontId[0]);
-    } else if (this.storefrontId) {
+    } else if (this.storefrontId && !Array.isArray(this.storefrontId)) {
       return this.props.client.product.fetch(this.storefrontId);
     } else if (this.handle) {
       return this.props.client.product.fetchByHandle(this.handle).then((product) => product);

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -377,6 +377,17 @@ describe('Product Component class', () => {
         assert.equal(data, fetchHandleData);
       });
 
+      it('rejects if there is an empty storefrontId array and no handle', async () => {
+        product.storefrontId = [];
+        product.handle = null;
+        try {
+          await product.sdkFetch();
+          assert.fail();
+        } catch (err) {
+          assert.equal(err.message, 'SDK Fetch Failed');
+        }
+      });
+
       it('rejects if there is no storefrontId or handle', async () => {
         product.storefrontId = null;
         product.handle = null;

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -388,6 +388,39 @@ describe('Product Component class', () => {
         }
       });
 
+      it('rejects if there is a falsey storefrontId array [null] and no handle', async () => {
+        product.storefrontId = [null];
+        product.handle = null;
+        try {
+          await product.sdkFetch();
+          assert.fail();
+        } catch (err) {
+          assert.equal(err.message, 'SDK Fetch Failed');
+        }
+      });
+
+      it('rejects if there is a falsey storefrontId array [""] and no handle', async () => {
+        product.storefrontId = [""];
+        product.handle = null;
+        try {
+          await product.sdkFetch();
+          assert.fail();
+        } catch (err) {
+          assert.equal(err.message, 'SDK Fetch Failed');
+        }
+      });
+
+      it('rejects if there is a falsey storefrontId array [0] and no handle', async () => {
+        product.storefrontId = [0];
+        product.handle = null;
+        try {
+          await product.sdkFetch();
+          assert.fail();
+        } catch (err) {
+          assert.equal(err.message, 'SDK Fetch Failed');
+        }
+      });
+
       it('rejects if there is no storefrontId or handle', async () => {
         product.storefrontId = null;
         product.handle = null;


### PR DESCRIPTION
When storefrontId is an empty array, we still attempt to make a JS Buy SDK call to Storefront API. We should be more defensive and not make SDK calls in this case.

The API response from one of these calls is:
```
{"errors":[{"message":"Variable id of type ID! was provided invalid value","locations":[{"line":1,"column":804}],"extensions":{"value":null,"problems":[{"path":[],"explanation":"Expected value to not be null"}]}}]}
```