### PR TITLE
Fix margin top spacing for collection product tiles

### DIFF
--- a/src/styles/embeds/sass/components/collection.css
+++ b/src/styles/embeds/sass/components/collection.css
@@ -17,7 +17,7 @@
   display: inline-block;
   vertical-align: top;
 
-  & + & {
+  & + .shopify-buy__product {
     margin-top: var(--gutter);
   }
 
@@ -26,7 +26,7 @@
     margin-left: var(--gutter-collection);
     margin-bottom: 50px;
 
-    & + & {
+    & + .shopify-buy__product {
       margin-top: 0;
     }
   }

--- a/src/styles/embeds/sass/components/select.css
+++ b/src/styles/embeds/sass/components/select.css
@@ -23,7 +23,7 @@
 }
 
 .shopify-buy__option-select {
-  & + & {
+  & + .shopify-buy__option-select {
     margin-top: calc(var(--gutter) / 2);
   }
 }


### PR DESCRIPTION
Due to a `PostCSS` spec difference from `SCSS`, the top margin for collection product tiles were not compiled correctly. 