### PR TITLE
Bump shopify-buy to v2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "morphdom": "2.5.5",
     "mustache": "3.0.1",
     "node-sass": "4.12.0",
-    "shopify-buy": "2.7.1",
+    "shopify-buy": "2.9.0",
     "uglify-js": "3.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6319,10 +6319,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.7.1.tgz#38134dbb06f69c4e3cf57dbbc3a7d23c35406c34"
-  integrity sha512-MZQrKAcHpZhH4YAgYwna4qI5KrveBcafEvpINF36mx6TcPh/hVZCaI8ahHRr/wn3O0NX5Pp9NaWgqiGDz282Rg==
+shopify-buy@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.9.0.tgz#72e7e86d2d89459feaa904d54bcaf1d8550240b0"
+  integrity sha512-ffDYRhqkSXwnd5EwcI1OpcOBQvQXLtPiuqAZMwcchz58kIBZGru3GWUQRBEL4ArEwuKlb0g7m9zCHy5hkoGjkw==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
Upgrade shopify buy to v2.9.0 which includes:
* Support for unit pricing
* New 2020-01 schema

To 🎩 : 
* Verify that product and collection buy buttons render as expected 
* Verify that pagination still works for multi-page collection buy buttons