### PR TITLE
Update JS Buy SDK to v2.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "morphdom": "2.5.5",
     "mustache": "3.0.1",
     "node-sass": "4.12.0",
-    "shopify-buy": "2.9.0",
+    "shopify-buy": "2.9.2",
     "uglify-js": "3.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6322,10 +6322,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.9.0.tgz#72e7e86d2d89459feaa904d54bcaf1d8550240b0"
-  integrity sha512-ffDYRhqkSXwnd5EwcI1OpcOBQvQXLtPiuqAZMwcchz58kIBZGru3GWUQRBEL4ArEwuKlb0g7m9zCHy5hkoGjkw==
+shopify-buy@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.9.2.tgz#a976c602d3cca445cacfdc66e0fce3ff8fa8387e"
+  integrity sha512-gfUuiQ/oOfFhNu3TlRnyCO/wIBGqvhHxXUwdMfx5kHrPQOkhsc0MaKz0+OS4K6Z0HuuE9p6oLZyRuz6kon1E4Q==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
Update JS Buy SDK to `v2.9.2` - this fixes possibility of Storefront API/JS Buy SDK from returning language content and creating a checkout based on the user's browser's language settings.