### PR TITLE
Fixed issue #672 - multiple collections rendered in random DOMs regardless of client config when iframe for productSet is FALSE

### DIFF
--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -225,7 +225,6 @@ export default class ProductSet extends Component {
       }),
     });
 
-    // fix for #672
     if (this.config.productSet.iframe === false) {
       productConfig.node = this.node.querySelector(`.${this.classes.productSet.products}`);
     }

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -227,8 +227,7 @@ export default class ProductSet extends Component {
 
     // fix for #672
     if (this.config.productSet.iframe === false) {
-        productConfig.node = this.node.querySelector(
-            ".".concat(this.classes.productSet.products));
+      productConfig.node = this.node.querySelector(`.${this.classes.productSet.products}`);
     }
 
     const promises = this.model.products.map((productModel) => {

--- a/src/components/product-set.js
+++ b/src/components/product-set.js
@@ -225,6 +225,12 @@ export default class ProductSet extends Component {
       }),
     });
 
+    // fix for #672
+    if (this.config.productSet.iframe === false) {
+        productConfig.node = this.node.querySelector(
+            ".".concat(this.classes.productSet.products));
+    }
+
     const promises = this.model.products.map((productModel) => {
       const product = new Product(productConfig, this.props);
       this.products.push(product);


### PR DESCRIPTION
This should fix #672 - conditional check if productSet iframe is false

Added a conditional to ```productConfig``` ```node``` setting in   ```ProductSet``` ```renderProducts``` method 

```javascript
    const productConfig = Object.assign({}, this.globalConfig, {
      node: this.view.document.querySelector(`.${this.classes.productSet.products}`),
      options: merge({}, this.config, {
        product: {
          iframe: false,
          classes: {
            wrapper: this.classes.productSet.product,
          },
        },
      }),
    });

    // fix for #672 - code updated after the 'build fail'
    if (this.config.productSet.iframe === false) {
      productConfig.node = this.node.querySelector(`.${this.classes.productSet.products}`);
    }

```