### PR TITLE
Fix CSS class for a product's disabled button

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -274,7 +274,7 @@ export default class Product extends Component {
   }
 
   get buttonClass() {
-    const disabledClass = this.buttonEnabled ? '' : this.classes.disabled;
+    const disabledClass = this.buttonEnabled ? '' : this.classes.product.disabled;
     const quantityClass = this.options.contents.buttonWithQuantity ? this.classes.product.buttonBesideQty : '';
     return `${disabledClass} ${quantityClass}`;
   }

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1680,12 +1680,12 @@ describe('Product Component class', () => {
 
         it('contains disabled class if button is not enabled', () => {
           product.buttonEnabled = false;
-          assert.include(product.buttonClass, product.classes.disabled);
+          assert.include(product.buttonClass, product.classes.product.disabled);
         });
 
         it('does not contain disabled class if button is enabled', () => {
           product.buttonEnabled = true;
-          assert.notInclude(product.buttonClass, product.classes.disabled);
+          assert.notInclude(product.buttonClass, product.classes.product.disabled);
         });
 
         it('contains buttonBesideQty class if button has quantity', () => {


### PR DESCRIPTION
Currently, when a product's button is disabled (e.g. no stock), it's rendered with `undefined` as class:

```html
<button disabled="" class="shopify-buy__btn undefined " data-element="product.button"></button>
```

This patch fixes this by using the intended default class `shopify-buy__btn-disabled`:

```html
<button disabled="" class="shopify-buy__btn shopify-buy__btn-disabled " data-element="product.button"></button>
```