### PR TITLE
Bump js-buy-sdk to v2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "morphdom": "2.5.5",
     "mustache": "3.0.1",
     "node-sass": "4.12.0",
-    "shopify-buy": "2.9.2",
+    "shopify-buy": "2.10.0",
     "uglify-js": "3.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6322,10 +6322,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.9.2.tgz#a976c602d3cca445cacfdc66e0fce3ff8fa8387e"
-  integrity sha512-gfUuiQ/oOfFhNu3TlRnyCO/wIBGqvhHxXUwdMfx5kHrPQOkhsc0MaKz0+OS4K6Z0HuuE9p6oLZyRuz6kon1E4Q==
+shopify-buy@2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.10.0.tgz#ed5e434e6f9b11de6626f5dfe8dc6a01a6f6a607"
+  integrity sha512-ZusCW1qxnlXrEqeeo3OoK7DbkAhppSrzhHHtDbOMpZXj91WEPZr8vQG9+IbeQXq/j+H3/wpzOJ+kF3WGrsDB7w==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
* Update `shopify-buy` package to latest version ([v2.10.0](https://github.com/Shopify/js-buy-sdk/releases/tag/v2.10.0)) 