### PR TITLE
Prevent modal.events.closeModal from being called multiple times

### DIFF
--- a/src/views/modal.js
+++ b/src/views/modal.js
@@ -11,6 +11,9 @@ export default class ModalView extends View {
    */
   close() {
     this.component.isVisible = false;
+    if (this.wrapper && this._closeOnBgClick) {
+      this.wrapper.removeEventListener('click', this._closeOnBgClick);
+    }
     removeClassFromElement('is-active', this.wrapper);
     removeClassFromElement('is-active', this.document.body);
     removeClassFromElement('shopify-buy-modal-is-active', document.body);
@@ -36,7 +39,8 @@ export default class ModalView extends View {
    */
   delegateEvents() {
     super.delegateEvents();
-    this.wrapper.addEventListener('click', this.component.closeOnBgClick.bind(this.component));
+    this._closeOnBgClick = this.component.closeOnBgClick.bind(this.component);
+    this.wrapper.addEventListener('click', this._closeOnBgClick);
   }
 
   render() {


### PR DESCRIPTION
Currently, each time a product modal is opened, a new click event listener is added to the same unique overlay. So, when the uses clicks outside of the modal to close it, the event `options.modal.events.closeModal` (if any) is called multiple times, one for each time a modal has been opened. 

This patch fixes this by calling `removeEventListener` for the overlay click event when the modal is closed.