### PR TITLE
Add focus trap when cart or modal are open

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -7,6 +7,7 @@ import formatMoney from '../utils/money';
 import CartView from '../views/cart';
 import CartUpdater from '../updaters/cart';
 import {addClassToElement} from '../utils/element-class';
+import {removeTrapFocus} from '../utils/focus';
 
 export const NO_IMG_URL = '//sdks.shopifycdn.com/buy-button/latest/no-image.jpg';
 
@@ -291,6 +292,7 @@ export default class Cart extends Component {
   close() {
     this.isVisible = false;
     this.view.render();
+    removeTrapFocus(this.view.wrapper);
   }
 
   /**

--- a/src/utils/focus.js
+++ b/src/utils/focus.js
@@ -1,0 +1,55 @@
+const TAB_KEY = 9;
+const trapFocusHandlers = {};
+
+export function removeTrapFocus(container) {
+  if (trapFocusHandlers.focusin) {
+    container.removeEventListener("focusin", trapFocusHandlers.focusin);
+  } 
+  if (trapFocusHandlers.focusout) {
+    container.removeEventListener("focusout", trapFocusHandlers.focusout);
+  }
+  if (trapFocusHandlers.keydown) {
+    container.removeEventListener("keydown", trapFocusHandlers.keydown);
+  }
+}
+
+export function trapFocus(container) {
+  const focusableElements = container.querySelectorAll("a, button:enabled, input:enabled, select:enabled");
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  removeTrapFocus(container);
+
+  trapFocusHandlers.focusin = function (event) {
+    if (event.target !== firstElement && event.target !== lastElement) { 
+      return;
+    }
+
+    container.addEventListener("keydown", trapFocusHandlers.keydown);
+  };
+
+  trapFocusHandlers.focusout = function () {
+    container.removeEventListener("keydown", trapFocusHandlers.keydown);
+  };
+
+  trapFocusHandlers.keydown = function (event) {
+    if (event.keyCode !== TAB_KEY) { 
+      return;
+    }
+
+    if (event.target === lastElement && !event.shiftKey) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+
+    if (event.target === firstElement && event.shiftKey) {
+      event.preventDefault();
+      lastElement.focus();
+    }
+  };
+
+  container.addEventListener("focusout", trapFocusHandlers.focusout);
+  container.addEventListener("focusin", trapFocusHandlers.focusin);
+
+  firstElement.focus();
+}

--- a/src/view.js
+++ b/src/view.js
@@ -3,6 +3,7 @@ import Template from './template';
 import Iframe from './iframe';
 import styles from './styles/embeds/all';
 import {addClassToElement, removeClassFromElement} from './utils/element-class';
+import {trapFocus} from './utils/focus';
 
 const delegateEventSplitter = /^(\S+)\s*(.*)$/;
 const ESC_KEY = 27;
@@ -187,13 +188,10 @@ export default class View {
   }
 
   /**
-   * Focus first focusable element in wrapper.
+   * Trap focus in the wrapper.
    */
   setFocus() {
-    const focusable = this.wrapper.querySelectorAll('a, button, input, select')[0];
-    if (focusable) {
-      focusable.focus();
-    }
+    trapFocus(this.wrapper);
   }
 
   /**

--- a/src/views/modal.js
+++ b/src/views/modal.js
@@ -1,5 +1,6 @@
 import View from '../view';
 import {addClassToElement, removeClassFromElement} from '../utils/element-class';
+import {removeTrapFocus} from '../utils/focus';
 
 export default class ModalView extends View {
   wrapTemplate(html) {
@@ -11,6 +12,7 @@ export default class ModalView extends View {
    */
   close() {
     this.component.isVisible = false;
+    removeTrapFocus(this.wrapper);
     if (this.wrapper && this._closeOnBgClick) {
       this.wrapper.removeEventListener('click', this._closeOnBgClick);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,7 @@ import './unit/money';
 import './unit/normalize-config';
 import './unit/detect-features';
 import './unit/unit-price';
+import './unit/focus';
 
 window.chai = chai;
 window.sinon = sinon;

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -8,6 +8,7 @@ import CartView from '../../src/views/cart';
 import ShopifyBuy from '../../src/buybutton';
 import * as formatMoney from '../../src/utils/money';
 import * as elementClass from '../../src/utils/element-class';
+import * as focusUtils from '../../src/utils/focus';
 
 let cart;
 
@@ -1337,6 +1338,38 @@ describe('Cart class', () => {
         quantity: 5,
         sku: null,
       });
+    });
+  });
+
+
+  describe('close()', () => {
+    let viewRenderSpy;
+    let removeTrapFocusStub;
+
+    beforeEach(() => {
+      viewRenderSpy = sinon.spy();
+      cart.view.render = viewRenderSpy;
+      removeTrapFocusStub = sinon.stub(focusUtils, 'removeTrapFocus');
+      cart.isVisible = true;
+
+      cart.close();
+    });
+
+    afterEach(() => {
+      removeTrapFocusStub.restore();
+    });
+
+    it('sets isVisible to false', () => {
+      assert.equal(cart.isVisible, false);
+    });
+
+    it('calls the view`s render function', () => {
+      assert.calledOnce(viewRenderSpy);
+    });
+
+    it('calls removeTrapFocus with the view wrapper', () => {
+      assert.calledOnce(removeTrapFocusStub);
+      assert.calledWith(removeTrapFocusStub.firstCall, cart.view.wrapper);
     });
   });
 });

--- a/test/unit/focus.js
+++ b/test/unit/focus.js
@@ -1,0 +1,191 @@
+import {trapFocus, removeTrapFocus} from '../../src/utils/focus';
+
+describe('Focus utils', () => {
+  let node;
+  let firstEl;
+  let middleEl;
+  let lastEl;
+
+  beforeEach(() => {
+    node = document.createElement('div');
+    firstEl = document.createElement('button');
+    middleEl = document.createElement('input');
+    lastEl = document.createElement('select');
+
+    node.appendChild(firstEl);
+    node.appendChild(middleEl);
+    node.appendChild(lastEl);
+    document.body.appendChild(node);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(node);
+  });
+
+  describe('trapFocus', () => {
+    it('focuses the first element', () => {
+      const focusSpy = sinon.spy();
+
+      firstEl.focus = focusSpy;
+      trapFocus(node);
+
+      assert.calledOnce(focusSpy);
+    });
+
+    describe('Focus events', () => {
+      let addEventListenerSpy;
+      let removeEventListenerSpy;
+
+      beforeEach(() => {
+        addEventListenerSpy = sinon.spy();
+        removeEventListenerSpy = sinon.spy();
+        node.addEventListener = addEventListenerSpy;
+        node.removeEventListener = removeEventListenerSpy;
+
+        trapFocus(node);
+      });
+
+      it('adds focusin and focusout event handlers', () => {
+        assert.calledTwice(addEventListenerSpy);
+        assert.calledWith(addEventListenerSpy.firstCall, 'focusout');
+        assert.calledWith(addEventListenerSpy.secondCall, 'focusin');
+      });
+
+      it('adds a keydown event listener if the focusin event handler is called on the first focusable element', () => {
+        const mockEvent = {
+          target: firstEl,
+        };
+        addEventListenerSpy.getCall(1).args[1](mockEvent);
+
+        assert.calledThrice(addEventListenerSpy);
+        assert.calledWith(addEventListenerSpy.thirdCall, 'keydown');
+      });
+
+      it('adds a keydown event listener if the focusin event handler is called on the last focusable element', () => {
+        const mockEvent = {
+          target: lastEl,
+        };
+        addEventListenerSpy.getCall(1).args[1](mockEvent);
+
+        assert.calledThrice(addEventListenerSpy);
+        assert.calledWith(addEventListenerSpy.thirdCall, 'keydown');
+      });
+
+      it('does not add a keydown event listener if the focusin event handler is called on a focusable element that is not first or last', () => {
+        const mockEvent = {
+          target: middleEl,
+        };
+        addEventListenerSpy.getCall(1).args[1](mockEvent);
+
+        assert.calledTwice(addEventListenerSpy);
+      });
+
+      it('removes the keydown event if the focusout event handle is called', () => {
+        removeEventListenerSpy.resetHistory();
+        addEventListenerSpy.getCall(0).args[1]();
+
+        assert.calledOnce(removeEventListenerSpy);
+        assert.calledWith(removeEventListenerSpy.firstCall, 'keydown');
+      });
+    });
+
+    describe('removeTrapFocus call', () => {
+      it('removes the focusin, focusout, and keydown event handlers from the node provided if they currently exist', () => {  
+        trapFocus(node);
+
+        const removeEventListenerSpy = sinon.spy();
+        node.removeEventListener = removeEventListenerSpy;
+        trapFocus(node);
+
+        assert.calledThrice(removeEventListenerSpy);
+        assert.calledWith(removeEventListenerSpy.firstCall, 'focusin');
+        assert.calledWith(removeEventListenerSpy.secondCall, 'focusout');
+        assert.calledWith(removeEventListenerSpy.thirdCall, 'keydown');
+      });
+    });
+
+    describe('Keydown event', () => {
+      let addEventListenerSpy;
+      let preventDefaultSpy;
+      let focusinHandler;
+      let keydownHandler;
+
+      beforeEach(() => {
+        preventDefaultSpy = sinon.spy();
+        addEventListenerSpy = sinon.spy(node, 'addEventListener');
+        trapFocus(node);
+        focusinHandler = addEventListenerSpy.getCall(1).args[1];
+      });
+
+      describe('First element', () => {
+        beforeEach(() => {
+          focusinHandler({
+            target: firstEl,
+          });
+          keydownHandler = addEventListenerSpy.getCall(2).args[1];
+        });
+
+        it('focuses the last element if shift+tab is pressed when focused on the first element', () => {
+          const focusSpy = sinon.spy();
+          lastEl.focus = focusSpy;
+          keydownHandler({keyCode: 9, shiftKey: true, target: firstEl, preventDefault: preventDefaultSpy});
+
+          assert.calledOnce(focusSpy);
+          assert.calledOnce(preventDefaultSpy);
+        });
+
+        it('does not focus the last element if a non shift+tab key is pressed when focused on the first element', () => {
+          const focusSpy = sinon.spy();
+          lastEl.focus = focusSpy;
+          keydownHandler({keyCode: 10, shiftKey: true, target: firstEl, preventDefault: preventDefaultSpy});
+
+          assert.notCalled(focusSpy);
+          assert.notCalled(preventDefaultSpy);
+        });
+      });
+
+      describe('Last element', () => {
+        beforeEach(() => {
+          focusinHandler({
+            target: lastEl,
+          });
+          keydownHandler = addEventListenerSpy.getCall(2).args[1];
+        });
+
+        it('focuses the first element if tab is pressed when focused on the last element', () => {
+          const focusSpy = sinon.spy();
+          firstEl.focus = focusSpy;
+          keydownHandler({keyCode: 9, shiftKey: false, target: lastEl, preventDefault: preventDefaultSpy});
+
+          assert.calledOnce(focusSpy);
+          assert.calledOnce(preventDefaultSpy);
+        });
+
+        it('does not focus the first element if a non tab key is pressed when focused on the last element', () => {
+          const focusSpy = sinon.spy();
+          firstEl.focus = focusSpy;
+          keydownHandler({keyCode: 10, shiftKey: false, target: lastEl, preventDefault: preventDefaultSpy});
+
+          assert.notCalled(focusSpy);
+          assert.notCalled(preventDefaultSpy);
+        });
+      });
+    });
+  });
+
+  describe('removeTrapFocus', () => {
+    it('removes the focusin, focusout, and keydown event handlers from the node provided', () => {
+      trapFocus(node);
+
+      const removeEventListenerSpy = sinon.spy();
+      node.removeEventListener = removeEventListenerSpy;
+
+      removeTrapFocus(node);
+
+      assert.calledThrice(removeEventListenerSpy);
+      assert.calledWith(removeEventListenerSpy.firstCall, 'focusin');
+      assert.calledWith(removeEventListenerSpy.secondCall, 'focusout');
+      assert.calledWith(removeEventListenerSpy.thirdCall, 'keydown');
+    });
+  });
+});

--- a/test/unit/modal/modal-view.js
+++ b/test/unit/modal/modal-view.js
@@ -1,6 +1,7 @@
 import Modal from '../../../src/components/modal';
 import View from '../../../src/view';
 import * as elementClass from '../../../src/utils/element-class';
+import * as focusUtils from '../../../src/utils/focus';
 
 describe('Modal View class', () => {
   const props = {
@@ -34,12 +35,15 @@ describe('Modal View class', () => {
 
   describe('close', () => {
     let removeClassFromElementStub;
+    let removeTrapFocusStub;
 
     beforeEach(() => {
       removeClassFromElementStub = sinon.stub(
         elementClass,
         'removeClassFromElement'
       );
+
+      removeTrapFocusStub = sinon.stub(focusUtils, 'removeTrapFocus');
 
       modal.view = Object.defineProperty(modal.view, 'document', {
         value: document,
@@ -48,6 +52,7 @@ describe('Modal View class', () => {
 
     afterEach(() => {
       removeClassFromElementStub.restore();
+      removeTrapFocusStub.restore();
     });
 
     it('sets the modal to not visible', () => {
@@ -97,6 +102,13 @@ describe('Modal View class', () => {
         'is-block',
         modal.node
       );
+    });
+
+    it('calls removeTrapFocus with the wrapper', () => {
+      modal.view.close();
+
+      assert.calledOnce(removeTrapFocusStub);
+      assert.calledWith(removeTrapFocusStub.firstCall, modal.view.wrapper);
     });
 
     describe('removing wrapper click event', () => {

--- a/test/unit/view.js
+++ b/test/unit/view.js
@@ -3,6 +3,7 @@ import Component from '../../src/component';
 import Template from '../../src/template';
 import Iframe from '../../src/iframe';
 import * as elementClass from '../../src/utils/element-class';
+import * as focusUtils from '../../src/utils/focus';
 
 describe('View class', () => {
   describe('constructor', () => {
@@ -486,14 +487,12 @@ describe('View class', () => {
     });
 
     describe('setFocus()', () => {
-      it('focuses first focusable element in wrapper', () => {
-        view.wrapper = document.createElement('div');
-        view.wrapper.append(document.createElement('a'));
-        view.wrapper.append(document.createElement('button'));
-        const focusStub = sinon.stub(view.wrapper.firstElementChild, 'focus');
+      it('calls trapFocus with the view wrapper', () => {
+        const trapFocusStub = sinon.stub(focusUtils, 'trapFocus');
         view.setFocus();
-        assert.calledOnce(focusStub);
-        focusStub.restore();
+        assert.calledOnce(trapFocusStub);
+        assert.calledWith(trapFocusStub.firstCall, view.wrapper);
+        trapFocusStub.restore();
       });
     });
 


### PR DESCRIPTION
* Add a common utility to trap focus within a given container
  * This function also focuses the first element in the container by default
* Call focus trap function from existing `setFocus` function, which is used by both the cart and modal
  * The first element focusing was removed from `setFocus` since that is handled in the focus trap function
* Update modal and cart to remove the focus trap event listeners on close

To 🎩 : 
Cart:
* Open the cart
* Continuously tab forwards through the cart and verify that focus stays in the cart
* Continuously tab backwards through the cart and verify that focus stays in the cart
* Close the cart by hitting enter when focused on the close button
  * Focus will stay on the close button (will be fixed in a followup PR)
* Tab backwards and verify that other elements on the page can be focused
  * This is to test that the focus trap is removed when the cart is closed

Modal: 
* Open a product details modal
* Continuously tab forwards through the modal and verify that focus stays in the modal
* Continuously tab backwards through the modal and verify that focus stays in the modal
* Close the modal by hitting enter when focused on the close button
* Verify that focus is returned back to the `view product` button
* Tabbing forwards or backwards should focus on other page elements as expected
