### PR TITLE
Add price and compare at price accessibility labels

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -186,7 +186,7 @@ export default class Product extends Component {
    * @return {String}
    */
   get formattedCompareAtPrice() {
-    if (!this.selectedVariant || !this.selectedVariant.compareAtPriceV2) {
+    if (!this.hasCompareAtPrice) {
       return '';
     }
     return formatMoney(this.selectedVariant.compareAtPriceV2.amount, this.globalConfig.moneyFormat);
@@ -252,7 +252,10 @@ export default class Product extends Component {
       quantityClass: this.quantityClass,
       priceClass: this.priceClass,
       formattedPrice: this.formattedPrice,
+      priceAccessibilityLabel: this.priceAccessibilityLabel,
+      hasCompareAtPrice: this.hasCompareAtPrice,
       formattedCompareAtPrice: this.formattedCompareAtPrice,
+      compareAtPriceAccessibilityLabel: this.compareAtPriceAccessibilityLabel,
       showUnitPrice: this.showUnitPrice,
       formattedUnitPrice: this.formattedUnitPrice,
       formattedUnitPriceBaseUnit: this.formattedUnitPriceBaseUnit,
@@ -331,7 +334,7 @@ export default class Product extends Component {
   }
 
   get priceClass() {
-    return this.selectedVariant && this.selectedVariant.compareAtPriceV2 ? this.classes.product.loweredPrice : '';
+    return this.hasCompareAtPrice ? this.classes.product.loweredPrice : '';
   }
 
   get isButton() {
@@ -841,4 +844,15 @@ export default class Product extends Component {
     return altText || this.model.title;
   }
 
+  get priceAccessibilityLabel() {
+    return this.hasCompareAtPrice ? this.options.text.salePriceAccessibilityLabel : this.options.text.regularPriceAccessibilityLabel;
+  }
+
+  get compareAtPriceAccessibilityLabel() {
+    return this.hasCompareAtPrice ? this.options.text.regularPriceAccessibilityLabel : '';
+  }
+
+  get hasCompareAtPrice() {
+    return Boolean(this.selectedVariant && this.selectedVariant.compareAtPriceV2);
+  }
 }

--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -82,6 +82,8 @@ const defaults = {
       unavailable: 'Unavailable',
       unitPriceAccessibilityLabel: 'Unit price',
       unitPriceAccessibilitySeparator: 'per',
+      regularPriceAccessibilityLabel: 'Regular price',
+      salePriceAccessibilityLabel: 'Sale price',
     },
   },
   modalProduct: {

--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -36,8 +36,12 @@ const productTemplate = {
   options: '{{#data.hasVariants}}<div class="{{data.classes.product.options}}" data-element="product.options">{{{data.optionsHtml}}}</div>{{/data.hasVariants}}',
   price: `<div class="{{data.classes.product.prices}}" data-element="product.prices">
             {{#data.selectedVariant}}
+            <span class="visuallyhidden">{{data.priceAccessibilityLabel}}&nbsp;</span>
             <span class="{{data.classes.product.price}} {{data.priceClass}}" data-element="product.price">{{data.formattedPrice}}</span>
-            {{#data.selectedVariant.compareAtPrice}}<span class="{{data.classes.product.compareAt}}" data-element="product.compareAt">{{data.formattedCompareAtPrice}}</span>{{/data.selectedVariant.compareAtPrice}}
+            {{#data.hasCompareAtPrice}}
+            <span class="visuallyhidden">{{data.compareAtPriceAccessibilityLabel}}&nbsp;</span>
+            <span class="{{data.classes.product.compareAt}}" data-element="product.compareAt">{{data.formattedCompareAtPrice}}</span>
+            {{/data.hasCompareAtPrice}}
             {{#data.showUnitPrice}}
             <div class="{{data.classes.product.unitPrice}}" data-element="product.unitPrice">
               <span class="visuallyhidden">{{data.text.unitPriceAccessibilityLabel}}</span>

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1378,14 +1378,10 @@ describe('Product Component class', () => {
         });
 
         describe('formattedCompareAtPrice', () => {
-          it('returns empty string if there is no selected variant', () => {
-            product.selectedVariant = null;
-            assert.equal(product.formattedCompareAtPrice, '');
-          });
-
           it('returns empty string if there is no compare at price', () => {
-            product.selectedVariant.compareAtPriceV2 = null;
+            const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => false);
             assert.equal(product.formattedCompareAtPrice, '');
+            hasCompareAtPriceStub.restore();
           });
 
           it('returns formatted money with selected variant compare at price and money format from global config if there is a selected variant', () => {
@@ -1395,10 +1391,12 @@ describe('Product Component class', () => {
                 currencyCode: 'CAD',
               },
             };
+            const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => true);
             product.globalConfig = {moneyFormat: 'CAD'};
             assert.equal(product.formattedCompareAtPrice, formattedMoney);
             assert.calledOnce(formatMoneyStub);
             assert.calledWith(formatMoneyStub, product.selectedVariant.compareAtPriceV2.amount, product.globalConfig.moneyFormat);
+            hasCompareAtPriceStub.restore();
           });
         });
 
@@ -1584,8 +1582,20 @@ describe('Product Component class', () => {
           assert.equal(viewData.formattedPrice, product.formattedPrice);
         });
 
+        it('returns an object with priceAccessibilityLabel', () => {
+          assert.equal(viewData.priceAccessibilityLabel, product.priceAccessibilityLabel);
+        });
+
+        it('returns an object with hasCompareAtPrice', () => {
+          assert.equal(viewData.hasCompareAtPrice, product.hasCompareAtPrice);
+        });
+
         it('returns an object with formattedCompareAtPrice', () => {
           assert.equal(viewData.formattedCompareAtPrice, product.formattedCompareAtPrice);
+        });
+
+        it('returns an object with compareAtPriceAccessibilityLabel', () => {
+          assert.equal(viewData.compareAtPriceAccessibilityLabel, product.compareAtPriceAccessibilityLabel);
         });
 
         it('returns an object with carouslIndex', () => {
@@ -1933,6 +1943,7 @@ describe('Product Component class', () => {
 
       describe('priceClass', () => {
         it('returns loweredPrice class if selected variant has a compare at price', () => {
+          const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => true);
           product = Object.defineProperty(product, 'classes', {
             value: {
               product: {
@@ -1940,18 +1951,14 @@ describe('Product Component class', () => {
               },
             },
           });
-          product.selectedVariant = {
-            compareAtPriceV2: {
-              amount: '5.00',
-              currencyCode: 'CAD',
-            },
-          };
           assert.equal(product.priceClass, product.classes.product.loweredPrice);
+          hasCompareAtPriceStub.restore();
         });
 
         it('returns empty string if selected variant does not have a compare at price', () => {
-          product.selectedVariant = {compareAtPriceV2: null};
+          const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => false);
           assert.equal(product.priceClass, '');
+          hasCompareAtPriceStub.restore();
         });
       });
 
@@ -2469,6 +2476,54 @@ describe('Product Component class', () => {
             product.model.onlineStoreUrl = 'https://test.myshopify.com/products/123';
             assert.equal(product.onlineStoreURL, `https://test.myshopify.com/products/123${expectedQs}`);
           });
+        });
+      });
+
+      describe('priceAccessibilityLabel', () => {
+        it('returns the sale price label if the selected variant has a compare at price', () => {
+          const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => true);
+          assert.equal(product.priceAccessibilityLabel, product.options.text.salePriceAccessibilityLabel);
+          hasCompareAtPriceStub.restore();
+        });
+
+        it('returns the regular price label if the selected variant does not have a compare at price', () => {
+          const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => false);
+          assert.equal(product.priceAccessibilityLabel, product.options.text.regularPriceAccessibilityLabel);
+          hasCompareAtPriceStub.restore();
+        });
+      });
+
+      describe('compareAtPriceAccessibilityLabel', () => {
+        it('returns the regular price label if the selected variant has a compare at price', () => {
+          const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => true);
+          assert.equal(product.compareAtPriceAccessibilityLabel, product.options.text.regularPriceAccessibilityLabel);
+          hasCompareAtPriceStub.restore();
+        });
+
+        it('returns an empty string if the selected variant does not have a compare at price', () => {
+          const hasCompareAtPriceStub = sinon.stub(product, 'hasCompareAtPrice').get(() => false);
+          assert.equal(product.compareAtPriceAccessibilityLabel, '');
+          hasCompareAtPriceStub.restore();
+        });
+      });
+
+      describe('hasCompareAtPrice', () => {
+        it('returns false if there is no selected variant', () => {
+          product.selectedVariant = null;
+          assert.equal(product.hasCompareAtPrice, false);
+        });
+
+        it('returns false if the selected variant does not have a compare at price', () => {
+          product.selectedVariant.compareAtPriceV2 = null;
+          assert.equal(product.hasCompareAtPrice, false);
+        });
+
+        it('returns true if the selected variant has a compare at price', () => {
+          product.selectedVariant.compareAtPriceV2 = {
+            amount: '5.00',
+            currencyCode: 'CAD',
+          };
+          assert.equal(product.hasCompareAtPrice, true);
         });
       });
     });


### PR DESCRIPTION
* Add new helper functions in the product component to return the price and compare at price accessibility labels
  * Price accessibility label will return `regular price` if there is no compare at price
  * Price accessibility label will return `sale price` if there is a compare at price
  * Compare at price will return `regular price` if there is a compare at price
* Update template logic to use a helper function to determine if compare at price should be displayed
  * It was previously using the legacy `compareAtPrice` field on the variant's model 
* Add new text options to the product config

**To 🎩 :** 
* Create a buy button for a product that has a compare at price, and a product that does not have a compare at price
* Note: VoiceOver works best in safari

Product tile: 
* Navigate a virtual cursor (screen reader) to a product without a compare at price
* Verify that the screen reader announces `Regular price` before announcing the price
* Navigate a virtual cursor to a product with a compare at price
* Visually check that the compare at price appears
* Verify that the screen reader announces `Sale price` before the price, and `Regular price` before the compare at price

Modal: 
* Open a product details modal for a product without a compare at price
* Navigate a virtual cursor to a product without a compare at price
* Verify that the screen reader announces `Regular price` before announcing the price
* Open a product details modal for a product with a compare at price
* Visually check that the compare at price appears
* Navigate a virtual cursor to a product with a compare at price
* Verify that the screen reader announces `Sale price` before the price, and `Regular price` before the compare at price