### PR TITLE
Return focus to the right element when the cart is closed

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -428,7 +428,9 @@ export default class Cart extends Component {
         this.updateCache(this.model.lineItems);
         this.view.render();
         this.toggles.forEach((toggle) => toggle.view.render());
-        this.view.setFocus();
+        if (!openCart) {
+          this.view.setFocus();
+        }
         return checkout;
       });
     } else {
@@ -443,7 +445,9 @@ export default class Cart extends Component {
         this.updateCache(this.model.lineItems);
         this.view.render();
         this.toggles.forEach((toggle) => toggle.view.render());
-        this.view.setFocus();
+        if (!openCart) {
+          this.view.setFocus();
+        }
         return checkout;
       });
     }

--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -44,6 +44,7 @@ export default class Modal extends Component {
     return Object.assign({}, this.globalConfig, {
       node: this.productWrapper,
       options: merge({}, this.config),
+      modalProduct: true,
     });
   }
 

--- a/src/components/product.js
+++ b/src/components/product.js
@@ -82,6 +82,7 @@ export default class Product extends Component {
     this.selectedVariant = {};
     this.selectedOptions = {};
     this.selectedImage = null;
+    this.modalProduct = Boolean(config.modalProduct);
     this.updater = new ProductUpdater(this);
     this.view = new ProductView(this);
   }
@@ -649,7 +650,7 @@ export default class Product extends Component {
       this.props.closeModal();
       this._userEvent('addVariantToCart');
       this.props.tracker.trackMethod(this.cart.addVariantToCart.bind(this), 'Update Cart', this.selectedVariantTrackingInfo)(this.selectedVariant, this.selectedQuantity);
-      if (this.iframe) {
+      if (!this.modalProduct) {
         this.props.setActiveEl(target);
       }
     } else if (this.options.buttonDestination === 'modal') {

--- a/src/components/toggle.js
+++ b/src/components/toggle.js
@@ -36,6 +36,7 @@ export default class CartToggle extends Component {
 
   toggleCart(evt) {
     evt.stopPropagation();
+    this.props.setActiveEl(this.view.node);
     this.props.cart.toggleVisibility();
   }
 }

--- a/src/views/toggle.js
+++ b/src/views/toggle.js
@@ -57,6 +57,7 @@ export default class ToggleView extends View {
       if (evt.keyCode !== ENTER_KEY) {
         return;
       }
+      this.component.props.setActiveEl(this.node);
       this.component.props.cart.toggleVisibility(this.component.props.cart);
     });
   }

--- a/test/unit/cart.js
+++ b/test/unit/cart.js
@@ -742,6 +742,42 @@ describe('Cart class', () => {
         assert.notCalled(cartOpenStub);
       });
     });
+
+    it('does not call setFocus if the openCart parameter is true and the model exists', () => {
+      cart.model = {
+        id: modelId,
+      };
+
+      return cart.addVariantToCart(variant, quantity, true).then(() => {
+        assert.notCalled(setFocusStub);
+      });
+    });
+
+    it('does not call setFocus if the openCart parameter is true and the model does not exist', () => {
+      cart.model = null;
+
+      return cart.addVariantToCart(variant, quantity, true).then(() => {
+        assert.notCalled(setFocusStub);
+      });
+    });
+
+    it('calls setFocus if the openCart parameter is false and the model exist', () => {
+      cart.model = {
+        id: modelId,
+      };
+
+      return cart.addVariantToCart(variant, quantity, false).then(() => {
+        assert.calledOnce(setFocusStub);
+      });
+    });
+
+    it('calls setFocus if openCart parameter is false and the model does not exist', () => {
+      cart.model = null;
+
+      return cart.addVariantToCart(variant, quantity, false).then(() => {
+        assert.calledOnce(setFocusStub);
+      });
+    });
   });
 
   describe('get formattedTotal', () => {

--- a/test/unit/modal/modal-component.js
+++ b/test/unit/modal/modal-component.js
@@ -240,6 +240,10 @@ describe('Modal Component class', () => {
         it('returns object with options that holds config', () => {
           assert.deepInclude(modal.productConfig, {options: modal.config});
         });
+
+        it('returns object with modalProduct set to true', () => {
+          assert.deepInclude(modal.productConfig, {modalProduct: true});
+        });
       });
     });
   });

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -90,6 +90,18 @@ describe('Product Component class', () => {
     it('creates a new view', () => {
       assert.instanceOf(product.view, ProductView);
     });
+
+    it('sets modalProduct to false if it is not provided in the config', () => {
+      assert.equal(product.modalProduct, false);
+    });
+
+    it('sets modalProduct to true if it is set to true in the config', () => {
+      const modalProductConfig = Object.assign({}, constructorConfig);
+      modalProductConfig.modalProduct = true;
+      product = new Product(modalProductConfig, props);
+
+      assert.equal(product.modalProduct, true);
+    });
   });
 
   describe('prototype methods', () => {
@@ -543,11 +555,17 @@ describe('Product Component class', () => {
           addToCartStub.restore();
         });
 
-        it('sets target to active el if iframe exists', () => {
-          product.iframe = {};
+        it('sets the active element to the target if it is not a modal product', () => {
+          product.modalProduct = false;
           product.onButtonClick(evt, target);
           assert.calledOnce(setActiveElSpy);
           assert.calledWith(setActiveElSpy, target);
+        });
+
+        it('does not set the active element if it is a modal product', () => {
+          product.modalProduct = true;
+          product.onButtonClick(evt, target);
+          assert.notCalled(setActiveElSpy);
         });
       });
 

--- a/test/unit/toggle/toggle-component.js
+++ b/test/unit/toggle/toggle-component.js
@@ -47,10 +47,12 @@ describe('Toggle Component class', () => {
 
   describe('prototype methods', () => {
     let toggleVisibilitySpy;
+    let setActiveElSpy;
     let cart;
 
     beforeEach(() => {
       toggleVisibilitySpy = sinon.spy();
+      setActiveElSpy = sinon.spy();
       cart = {
         toggleVisibility: toggleVisibilitySpy,
         model: {
@@ -66,7 +68,7 @@ describe('Toggle Component class', () => {
           ],
         },
       };
-      toggle = new Toggle({node}, {cart});
+      toggle = new Toggle({node}, {cart, setActiveEl: setActiveElSpy});
     });
 
     describe('toggleCart()', () => {
@@ -86,6 +88,11 @@ describe('Toggle Component class', () => {
 
       it('toggles visibility in cart', () => {
         assert.calledOnce(toggleVisibilitySpy);
+      });
+
+      it('calls setActiveEl with the cart view node', () => {
+        assert.calledOnce(setActiveElSpy);
+        assert.calledWith(setActiveElSpy.firstCall, toggle.view.node);
       });
     });
 

--- a/test/unit/toggle/toggle-view.js
+++ b/test/unit/toggle/toggle-view.js
@@ -5,14 +5,19 @@ describe('Toggle View class', () => {
   let toggle;
   let cart;
   let toggleVisibilitySpy;
+  let setActiveElSpy;
 
   beforeEach(() => {
     toggleVisibilitySpy = sinon.spy();
+    setActiveElSpy = sinon.spy();
     cart = {
       toggleVisibility: toggleVisibilitySpy,
     };
     const node = document.createElement('div');
-    toggle = new Toggle({node}, {cart});
+    toggle = new Toggle({node}, {
+      cart,
+      setActiveEl: setActiveElSpy,
+    });
   });
 
   describe('render()', () => {
@@ -137,17 +142,20 @@ describe('Toggle View class', () => {
         assert.calledWith(addEventListenerSpy, 'keydown', sinon.match.func);
       });
 
-      it('does not toggle cart visibility if keydown event is not the enter key', () => {
+      it('does not toggle cart visibility or set the active element if keydown event is not the enter key', () => {
         const event = {keyCode: 999};
         addEventListenerSpy.getCall(0).args[1](event);
         assert.notCalled(toggleVisibilitySpy);
+        assert.notCalled(setActiveElSpy);
       });
 
-      it('toggles cart visibility if keydown event is the enter key', () => {
+      it('toggles cart visibility and sets the active element if keydown event is the enter key', () => {
         const event = {keyCode: 13}; // enter key
         addEventListenerSpy.getCall(0).args[1](event);
         assert.calledOnce(toggleVisibilitySpy);
         assert.calledWith(toggleVisibilitySpy, cart);
+        assert.calledWith(setActiveElSpy);
+        assert.calledWith(setActiveElSpy, toggle.view.node);
       });
     });
   });


### PR DESCRIPTION
* Add a new property to the product component to track whether the product is rendered in the modal or not
* Use the new property to determine whether or not the last active element should be set to the button when the add to cart button is clicked
  * If the product is not a modal product, the active element should be set so focus is returned to the button
  * If the product is a modal product, the active element should not be set because the modal is closed when the button is clicked, so focus should not be returned to that button in the modal
* Set the active element to the toggle when the cart is opened via the toggle 
  * This had to be set in two places since the click and keydown events are handled separately
* Fix a double call to `setFocus` when the cart is opened
  * Previously there was a race condition where the focus would be returned to the cart by the second `setFocus` if the cart was closed too quickly after being opened

**To 🎩 :**
Product: 
* Create a buy button for a single product where the button adds to cart
* Tab to the button, and add the item to cart by pressing enter 
* Once the cart is open, press enter when focused on the close button
* Verify that the focus is returned to the product's `add to cart` button
* Click the add to cart button using the mouse, and close the cart using the mouse
* Verify that the focus is returned to the product's `add to cart` button

Collection/Product Set:
* Create a buy button for a collection/product set where the button adds to cart
* Tab to one of the product buttons, and add the item to the cart by pressing enter
* Once the cart is open, press enter when focused on the close button
* Verify that focus is returned to the `add to cart` button for the product that was added
* Click the add to cart button for one of the products using the mouse, and close the cart using the mouse
* Verify that the focus is returned to the `add to cart` button for the product that was added

Modal: 
* Create a buy button for a product where the button opens the product details modal
* Tab to the button, and open the modal by pressing enter
* Once the modal is open, tab through the modal to the add to cart button
* Add the item by pressing enter (the modal should close then the cart opens)
* Once the cart is open, press enter when focused on the close button
* Verify that the focus is returned to the product's `view details` button
* Open the product details modal using the mouse, and add the product to cart using the mouse
* Close the cart using the mouse 
* Verify that the focus is returned to the product's `view details` button

Toggle: 
* Tab to the cart toggle, and open the cart by pressing enter
* Once the cart is open, press enter when focused on the close button
* Verify that focus is returned to the cart toggle
* Click the toggle using the mouse, and close the cart using the mouse
* Verify that focus is returned to the cart toggle