### PR TITLE
Prevent default event when triggering the cart toggle using the keydown event

### DIFF
--- a/src/views/toggle.js
+++ b/src/views/toggle.js
@@ -57,6 +57,7 @@ export default class ToggleView extends View {
       if (evt.keyCode !== ENTER_KEY) {
         return;
       }
+      evt.preventDefault();
       this.component.props.cart.toggleVisibility(this.component.props.cart);
     });
   }

--- a/test/unit/toggle/toggle-view.js
+++ b/test/unit/toggle/toggle-view.js
@@ -137,17 +137,25 @@ describe('Toggle View class', () => {
         assert.calledWith(addEventListenerSpy, 'keydown', sinon.match.func);
       });
 
-      it('does not toggle cart visibility if keydown event is not the enter key', () => {
-        const event = {keyCode: 999};
+      it('does not toggle cart visibility or call preventDefault if keydown event is not the enter key', () => {
+        const event = {
+          keyCode: 999,
+          preventDefault: sinon.spy()
+        };
         addEventListenerSpy.getCall(0).args[1](event);
         assert.notCalled(toggleVisibilitySpy);
+        assert.notCalled(event.preventDefault);
       });
 
-      it('toggles cart visibility if keydown event is the enter key', () => {
-        const event = {keyCode: 13}; // enter key
+      it('toggles cart visibility and calls preventDefault if keydown event is the enter key', () => {
+        const event = {
+          keyCode: 13, // enter key
+          preventDefault: sinon.spy(),
+        };
         addEventListenerSpy.getCall(0).args[1](event);
         assert.calledOnce(toggleVisibilitySpy);
         assert.calledWith(toggleVisibilitySpy, cart);
+        assert.calledOnce(event.preventDefault);
       });
     });
   });


### PR DESCRIPTION
* Fix a bug in firefox and legacy edge which prevented the cart from being opened by pressing the enter key on the keyboard
* When pressing the enter key, a custom event handler would trigger the cart to open, but it would subsequently also trigger a click on the cart's close button, which became focused during the custom handler

To 🎩 : 
* Tab to the cart toggle 
* Verify that cart toggle can be clicked by pressing the enter key 
* Verify that the cart can be tabbed through
* Verify that clicking `X` button in the cart closes the cart

Browsers to 🎩 : 
- [x] Safari - Mac
- [x] Chrome - Mac 
- [x] Edge - Mac 
- [x] Firefox - Mac
- [x] Legacy Edge - Windows
- [x] Edge - Windows
- [x] Chrome - Windows 
- [x] Firefox - Windows 