### PR TITLE
Toggle cart when space key is pressed

### DIFF
--- a/src/views/toggle.js
+++ b/src/views/toggle.js
@@ -1,6 +1,7 @@
 import View from '../view';
 
 const ENTER_KEY = 13;
+const SPACE_KEY = 32;
 
 export default class ToggleView extends View {
   get shouldResizeY() {
@@ -54,9 +55,10 @@ export default class ToggleView extends View {
       return;
     }
     this.iframe.parent.addEventListener('keydown', (evt) => {
-      if (evt.keyCode !== ENTER_KEY) {
+      if (evt.keyCode !== ENTER_KEY && evt.keyCode !== SPACE_KEY) {
         return;
       }
+      evt.preventDefault();
       this.component.props.setActiveEl(this.node);
       this.component.props.cart.toggleVisibility(this.component.props.cart);
     });

--- a/test/unit/toggle/toggle-view.js
+++ b/test/unit/toggle/toggle-view.js
@@ -126,9 +126,11 @@ describe('Toggle View class', () => {
 
     describe('when iframe exists', () => {
       let addEventListenerSpy;
+      let preventDefaultSpy;
 
       beforeEach(() => {
         addEventListenerSpy = sinon.spy();
+        preventDefaultSpy = sinon.spy();
         toggle.view.iframe = {
           parent: {
             addEventListener: addEventListenerSpy,
@@ -142,18 +144,39 @@ describe('Toggle View class', () => {
         assert.calledWith(addEventListenerSpy, 'keydown', sinon.match.func);
       });
 
-      it('does not toggle cart visibility or set the active element if keydown event is not the enter key', () => {
-        const event = {keyCode: 999};
+      it('does not toggle cart visibility, set the active element, or call preventDefault if keydown event is not the enter or space key', () => {
+        const event = {
+          keyCode: 999,
+          preventDefault: preventDefaultSpy,
+        };
         addEventListenerSpy.getCall(0).args[1](event);
         assert.notCalled(toggleVisibilitySpy);
+        assert.notCalled(preventDefaultSpy);
         assert.notCalled(setActiveElSpy);
       });
 
-      it('toggles cart visibility and sets the active element if keydown event is the enter key', () => {
-        const event = {keyCode: 13}; // enter key
+      it('toggles cart visibility, sets the active element, and calls preventDefault if keydown event is the enter key', () => {
+        const event = {
+          keyCode: 13, // enter key
+          preventDefault: preventDefaultSpy,
+        };
         addEventListenerSpy.getCall(0).args[1](event);
         assert.calledOnce(toggleVisibilitySpy);
         assert.calledWith(toggleVisibilitySpy, cart);
+        assert.calledOnce(preventDefaultSpy);
+        assert.calledWith(setActiveElSpy);
+        assert.calledWith(setActiveElSpy, toggle.view.node);
+      });
+
+      it('toggles cart visibility, sets the active element, and calls preventDefault if keydown event is the space key', () => {
+        const event = {
+          keyCode: 32, // space key
+          preventDefault: preventDefaultSpy,
+        };
+        addEventListenerSpy.getCall(0).args[1](event);
+        assert.calledOnce(toggleVisibilitySpy);
+        assert.calledWith(toggleVisibilitySpy, cart);
+        assert.calledOnce(preventDefaultSpy);
         assert.calledWith(setActiveElSpy);
         assert.calledWith(setActiveElSpy, toggle.view.node);
       });


### PR DESCRIPTION
* Currently, only the enter key can be pressed to trigger the cart toggle
* HTML buttons support both the enter and space key as click triggers when using the keyboard to navigate
* This PR adds support for using the space key to trigger the cart toggle 
  * It also calls `preventDefault()` on the event to stop the space key from trigger the page scroll as well 

To 🎩 : 
* Tab to the cart toggle
* Verify that cart opens when pressing the space key and the enter key
* Verify that when the space key is used, the page does not scroll down

Browsers: 
- [x] Safari - Mac 
- [x] Chrome - Mac 
- [x] Edge - Mac 
- [x] Firefox - Mac
  * There is a [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1487102) in firefox, which causes the cart to close after it's opened. Calling `preventDefault` in the keydown handler still causes it to emit a subsequent `click` event, which is triggered on the cart's close button
- [x] Legacy Edge - Windows
- [x] Edge - Windows
- [x] Chrome - Windows
- [x] Firefox - Windows 
  *  Experiences the same bug as Mac