### PR TITLE
Fix select focus state visibility in firefox

### DIFF
--- a/src/styles/embeds/sass/components/select.css
+++ b/src/styles/embeds/sass/components/select.css
@@ -4,7 +4,6 @@
   box-sizing: border-box;
   position: relative;
   background: var(--color-white);
-  overflow: hidden;
   vertical-align: bottom;
 }
 


### PR DESCRIPTION
* Remove `overflow: hidden` from the select wrapper so the focus state is not hidden in firefox 

To 🎩 : 
* Verify that the select elements have a visible focus state in the product tile and modal
* Verify that long variant names don't cause the content to overflow and scroll 

Browsers: 
- [x] Safari - Mac 
- [x] Chrome - Mac 
- [x] Firefox - Mac 
- [x] Edge - Mac 
- [x] Safari 8 - Mac
- [ ] Legacy Edge - Windows
  * Custom appearance of inputs overrides default browser focus indicators. Creating a completely custom focus state may be done as a followup, but should not block the fix for Firefox
- [x] Edge - Windows 
- [x] Chrome - Windows
- [x] Firefox - Windows 
- [x] IE11 - Windows
- [x] Safari - iOS
- [x] Chrome - Android