### PR TITLE
Update cart close accessibility label

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -239,6 +239,7 @@ const defaults = {
       currency: 'CAD',
       notice: 'Shipping and discount codes are added at checkout.',
       noteDescription: 'Special instructions for seller',
+      closeAccessibilityLabel: 'Close cart',
     },
   },
   lineItem: {

--- a/src/templates/cart.js
+++ b/src/templates/cart.js
@@ -2,8 +2,8 @@ const cartTemplates = {
   title: `<div class="{{data.classes.cart.header}}" data-element="cart.header">
             <h2 class="{{data.classes.cart.title}}" data-element="cart.title">{{data.text.title}}</h2>
             <button class="{{data.classes.cart.close}}" data-element="cart.close">
-              <span aria-role="hidden">&times;</span>
-              <span class="visuallyhidden">Close</span>
+              <span aria-hidden="true">&times;</span>
+              <span class="visuallyhidden">{{data.text.closeAccessibilityLabel}}</span>
              </button>
           </div>`,
   lineItems: `<div class="{{data.classes.cart.cartScroll}}{{#data.contents.note}} {{data.classes.cart.cartScrollWithCartNote}}{{/data.contents.note}}{{#data.discounts}} {{data.classes.cart.cartScrollWithDiscounts}}{{/data.discounts}}" data-element="cart.cartScroll">


### PR DESCRIPTION
* Use `aria-hidden="true"` instead of  `aria-role="hidden"` so the `X` is not read by the screen reader 
* Make the accessibility label configurable by exposing it in the cart options
* Update the label from `Close` to `Close cart` for clarity

**To 🎩 :** 
* Navigate a virtual cursor to the cart close button
* Verify that the screen reader does not announce `Times` (this is what it reads out for the `X`)
* Verify that the screen reader announces `Close cart` when the virtual cursor is on the close button
* Update the buy button config, and change the `cart > text > closeAccessibilityLabel` text and verify that it is reflected in the buy button

Browsers
- [x] Safari - Mac - VoiceOver
- [x] Firefox - Windows - NVDA
