### PR TITLE
Connect the cart note label to the textarea

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -135,6 +135,7 @@ export default class Cart extends Component {
       discounts: this.cartDiscounts,
       contents: this.options.contents,
       cartNote: this.cartNote,
+      cartNoteId: this.cartNoteId,
     });
   }
 
@@ -186,6 +187,10 @@ export default class Cart extends Component {
 
   get cartNote() {
     return this.model && this.model.note;
+  }
+
+  get cartNoteId() {
+    return `CartNote-${Date.now()}`;
   }
 
   get wrapperClass() {

--- a/src/templates/cart.js
+++ b/src/templates/cart.js
@@ -28,8 +28,8 @@ const cartTemplates = {
               <p class="{{data.classes.cart.subtotal}}" data-element="cart.subtotal">{{data.formattedTotal}}</p>
               {{#data.contents.note}}
                 <div class="{{data.classes.cart.note}}" data-element="cart.note">
-                  <p class="{{data.classes.cart.noteDescription}}" data-element="cart.noteDescription">{{data.text.noteDescription}}</p>
-                  <textarea class="{{data.classes.cart.noteTextArea}}" data-element="cart.noteTextArea" rows="3"/>{{data.cartNote}}</textarea>
+                  <label for="{{data.cartNoteId}}" class="{{data.classes.cart.noteDescription}}" data-element="cart.noteDescription">{{data.text.noteDescription}}</label>
+                  <textarea id="{{data.cartNoteId}}" class="{{data.classes.cart.noteTextArea}}" data-element="cart.noteTextArea" rows="3"/>{{data.cartNote}}</textarea>
                 </div>
               {{/data.contents.note}}
               <p class="{{data.classes.cart.notice}}" data-element="cart.notice">{{data.text.notice}}</p>

--- a/test/unit/cart/cart.js
+++ b/test/unit/cart/cart.js
@@ -16,10 +16,14 @@ describe('Cart class', () => {
   const moneyFormat = '${{amount}}';
   let closeCartSpy;
   let trackSpy;
+  let viewData;
+  const mockTime = 123;
+  let dateNowStub;
 
   beforeEach(() => {
     closeCartSpy = sinon.spy();
     trackSpy = sinon.spy();
+    dateNowStub = sinon.stub(Date, 'now').returns(mockTime);
 
     cart = new Cart({
       options: {
@@ -57,6 +61,7 @@ describe('Cart class', () => {
   });
 
   afterEach(() => {
+    dateNowStub.restore();
     cart.destroy();
   });
 
@@ -991,8 +996,6 @@ describe('Cart class', () => {
   });
 
   describe('viewData()', () => {
-    let viewData;
-
     describe('with model', () => {
       beforeEach(async () => {
         const lineItems = [
@@ -1059,6 +1062,10 @@ describe('Cart class', () => {
       it('returns an object with cart note', () => {
         assert.equal(viewData.cartNote, cart.cartNote);
       });
+
+      it('returns an object with cartNoteId', () => {
+        assert.equal(viewData.cartNoteId, cart.cartNoteId);
+      });
     });
 
     describe('without model', () => {
@@ -1093,6 +1100,10 @@ describe('Cart class', () => {
 
       it('returns an object with cart note', () => {
         assert.equal(viewData.cartNote, cart.cartNote);
+      });
+
+      it('returns an object with cartNoteId', () => {
+        assert.equal(viewData.cartNoteId, cart.cartNoteId);
       });
     });
   });
@@ -1140,6 +1151,12 @@ describe('Cart class', () => {
       cart.model.note = note;
 
       assert.equal(cart.cartNote, cart.model.note);
+    });
+  });
+
+  describe('get cartNoteId', () => {
+    it('returns a string containing the current time in ms', () => {
+      assert.equal(cart.cartNoteId, `CartNote-${mockTime}`);
     });
   });
 


### PR DESCRIPTION
* Create a helper in the cart component to create a unique id for the cart note input
  * Using a hardcoded id like `CartNote` might end up causing issues if the multiple non-iframe carts exist on the same page 
  * The helper uses `Date.now()` to ensure that the id is unique, and it is regenerated each time the cart is rendered
  * An alternative that was considered was to add a `createdAt` attribute to the cart, and set it to `Date.now()` in the constructor. However, there is still a chance that two carts could be created at the same time (depending on the JS execution time) 
* Add an `id` attribute to the cart note text area and set it to the unique id
* Change the cart note label from a `<p />` to a `<label />` and set it to the unique id 
* The `for` & `id` method was chosen instead of wrapping the input in a label since it is more robust across different screen readers

To 🎩  : 
* Create a buy button with a cart note
* Navigate through the cart with a virtual cursor
* Verify that the screen reader announced the label with the text area
* Create a buy button with multiple non-iframe carts 
* Verify that none of the cart notes have the same id

Browsers: 
- [x] Safari - Mac - VoiceOver
- [x] Firefox - Windows - NVDA