### PR TITLE
Increase opacity of compare at price to improve contrast

### DIFF
--- a/src/styles/embeds/sass/components/product.css
+++ b/src/styles/embeds/sass/components/product.css
@@ -115,7 +115,7 @@
   font-size: 12px;
   text-decoration: line-through;
   padding-left: 5px;
-  opacity: 0.65;
+  opacity: 0.76;
 }
 
 .shopify-buy__product__unit-price {


### PR DESCRIPTION
* Increase opacity to 0.76
* This is the minimum opacity where the default #4a4a4a colour will have a contrast of at least 4.5:1 on a white background

To 🎩 : 
* Create a buy button for a product with a compare at price 
* Verify that the opacity of the compare at price in the product tile is 0.76
* Verify that the opacity of the compare at price in the modal is 0.76