### PR TITLE
Update line item quantity accessibility labels

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -114,6 +114,7 @@ export default class Cart extends Component {
       data.formattedPrice = formattedPrice;
 
       data.classes = this.classes;
+      data.text = this.config.lineItem.text;
       data.lineItemImage = this.imageForLineItem(data);
       data.variantTitle = data.variant.title === 'Default Title' ? '' : data.variant.title;
       return acc + this.childTemplate.render({data}, (output) => `<div id="${lineItem.id}" class=${this.classes.lineItem.lineItem}>${output}</div>`);

--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -279,6 +279,11 @@ const defaults = {
       quantityIncrement: 'shopify-buy__quantity-increment',
       quantityDecrement: 'shopify-buy__quantity-decrement',
     },
+    text: {
+      quantityInputAccessibilityLabel: 'Quantity',
+      quantityDecrementAccessibilityLabel: 'Reduce item quantity by one',
+      quantityIncrementAccessibilityLabel: 'Increase item quantity by one',
+    },
   },
   toggle: {
     templates: toggleTemplates,

--- a/src/templates/line-item.js
+++ b/src/templates/line-item.js
@@ -23,11 +23,11 @@ const lineItemTemplates = {
                       </div>`,
   quantity: `<div class="{{data.classes.lineItem.quantity}}" data-element="lineItem.quantity">
               <button class="{{data.classes.lineItem.quantityButton}} {{data.classes.lineItem.quantityDecrement}}" type="button" data-line-item-id="{{data.id}}" data-element="lineItem.quantityDecrement">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M4 7h8v2H4z"/></svg><span class="visuallyhidden">Decrement</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M4 7h8v2H4z"/></svg><span class="visuallyhidden">{{data.text.quantityDecrementAccessibilityLabel}}</span>
               </button>
-              <input class="{{data.classes.lineItem.quantityInput}}" type="number" min="0" aria-label="Quantity" data-line-item-id="{{data.id}}" value="{{data.quantity}}" data-element="lineItem.quantityInput">
+              <input class="{{data.classes.lineItem.quantityInput}}" type="number" min="0" aria-label="{{data.text.quantityInputAccessibilityLabel}}" data-line-item-id="{{data.id}}" value="{{data.quantity}}" data-element="lineItem.quantityInput">
               <button class="{{data.classes.lineItem.quantityButton}} {{data.classes.lineItem.quantityIncrement}}" type="button" data-line-item-id="{{data.id}}" data-element="lineItem.quantityIncrement">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M12 7H9V4H7v3H4v2h3v3h2V9h3z"/></svg><span class="visuallyhidden">Increment</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M12 7H9V4H7v3H4v2h3v3h2V9h3z"/></svg><span class="visuallyhidden">{{data.text.quantityIncrementAccessibilityLabel}}</span>
               </button>
             </div>`,
 };

--- a/test/unit/cart/cart.js
+++ b/test/unit/cart/cart.js
@@ -14,6 +14,10 @@ let cart;
 
 describe('Cart class', () => {
   const moneyFormat = '${{amount}}';
+  const quantityInputAccessibilityLabel = 'quantity accessibility label';
+  const quantityDecrementAccessibilityLabel = 'quantity decrement accessibility label';
+  const quantityIncrementAccessibilityLabel = 'quantity increment accessibility label';
+
   let closeCartSpy;
   let trackSpy;
   let viewData;
@@ -34,6 +38,13 @@ describe('Cart class', () => {
           },
           text: {
             notice: 'test',
+          },
+        },
+        lineItem: {
+          text: {
+            quantityInputAccessibilityLabel,
+            quantityDecrementAccessibilityLabel,
+            quantityIncrementAccessibilityLabel,
           },
         },
       },
@@ -149,6 +160,30 @@ describe('Cart class', () => {
       const renderSpy = sinon.spy(cart.childTemplate, 'render');
       assert.include(cart.lineItemsHtml, 'data-line-item-id="123"');
       assert.calledOnce(renderSpy);
+    });
+
+    it('renders the quantity accessibility labels', () => {
+      cart.lineItemCache = [{
+        id: 123,
+        title: 'test',
+        variantTitle: 'test2',
+        quantity: 1,
+        variant: {
+          image: {
+            src: 'cdn.shopify.com/image.jpg',
+          },
+          priceV2: {
+            amount: '5.00',
+            currencyCode: 'CAD',
+          },
+        },
+        discountAllocations: [],
+      }];
+
+      const cartLineItemsHtml = cart.lineItemsHtml;
+      assert.include(cartLineItemsHtml, `aria-label="${quantityInputAccessibilityLabel}"`);
+      assert.include(cartLineItemsHtml, `<span class="visuallyhidden">${quantityDecrementAccessibilityLabel}</span>`);
+      assert.include(cartLineItemsHtml, `<span class="visuallyhidden">${quantityIncrementAccessibilityLabel}</span>`);
     });
 
     describe('price without discounts', () => {


### PR DESCRIPTION
* Update the visually hidden text on the decrement and increment button to be clearer
* Abstract out the quantity input aria-label into the config 

To 🎩 : 

* Navigate a virtual cursor through a cart with a line item
* Verify that the quantity decrement button label is `Reduce item quantity by one`
* Verify that the quantity input label is `Quantity` 
* Verify that the quantity increment button label is `Increase item quantity by one`
* Update the three new strings in the buy button config, and verify that they are applied to the buy button


- [x] Safari - Mac - VoiceOver 
- [x] Firefox - Windows - NVDA