### PR TITLE
Connect variant label to select

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -384,9 +384,11 @@ export default class Product extends Component {
       return '';
     }
 
-    return this.decoratedOptions.reduce((acc, option) => {
+    const uniqueId = Date.now();
+    return this.decoratedOptions.reduce((acc, option, index) => {
       const data = merge(option, this.options.viewData);
       data.classes = this.classes;
+      data.selectId = `Option-${uniqueId}-${index}`;
       data.onlyOption = (this.model.options.length === 1);
       return acc + this.childTemplate.render({data});
     }, '');

--- a/src/templates/option.js
+++ b/src/templates/option.js
@@ -1,8 +1,8 @@
 const optionTemplates = {
   option: `<div class="{{data.classes.option.option}}" data-element="option.option">
-    <label class="{{data.classes.option.label}} {{#data.onlyOption}}{{data.classes.option.hiddenLabel}}{{/data.onlyOption}}" data-element="option.label">{{data.name}}</label>
+    <label for="{{data.selectId}}" class="{{data.classes.option.label}} {{#data.onlyOption}}{{data.classes.option.hiddenLabel}}{{/data.onlyOption}}" data-element="option.label">{{data.name}}</label>
       <div class="{{data.classes.option.wrapper}}" data-element="option.wrapper">
-      <select class="{{data.classes.option.select}}" name="{{data.name}}" data-element="option.select">
+      <select id="{{data.selectId}}" class="{{data.classes.option.select}}" name="{{data.name}}" data-element="option.select">
         {{#data.values}}
           <option {{#selected}}selected{{/selected}} value="{{name}}">{{name}}</option>
         {{/data.values}}

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -18,6 +18,16 @@ const rootImageURI = 'https://cdn.shopify.com/s/files/1/0014/8583/2214/products/
 
 describe('Product Component class', () => {
   let product;
+  let dateNowStub;
+  const mockTime = 123;
+
+  beforeEach(() => {
+    dateNowStub = sinon.stub(Date, 'now').returns(mockTime);
+  });
+
+  afterEach(() => {
+    dateNowStub.restore();
+  });
 
   describe('constructor', () => {
     let normalizeConfigStub;
@@ -2189,6 +2199,13 @@ describe('Product Component class', () => {
           assert.isString(optionsHtml);
         });
 
+        it('adds a selectId to the rendered data object', () => {
+          const optionsHtml = product.optionsHtml;
+          const renderedData = renderStub.getCall(0).args[0].data;
+          assert.equal(renderedData.selectId, `Option-${mockTime}-0`);
+          assert.isString(optionsHtml);
+        });
+
         it('sets onlyOption in rendered data to true if there is only one option in model', () => {
           const optionsHtml = product.optionsHtml;
           const renderedData = renderStub.getCall(0).args[0].data;
@@ -2223,6 +2240,7 @@ describe('Product Component class', () => {
               test: 'test string',
               classes: product.classes,
               onlyOption: true,
+              selectId: `Option-${mockTime}-0`,
             },
           };
           const secondExpectedObject = {
@@ -2232,6 +2250,7 @@ describe('Product Component class', () => {
               test: 'test string',
               classes: product.classes,
               onlyOption: true,
+              selectId: `Option-${mockTime}-1`,
             },
           };
           assert.calledTwice(renderStub);


### PR DESCRIPTION
* Pass in a unique id to the option template, which is made up of the current time and the index of the option
* Set the option select's `id` attribute and the label's `for` attribute to this id

To 🎩 : 
* Create a collection buy button, with multiple products with multiple variants
* Verify in the DOM that none of the selects have the same id
* Navigate a virtual cursor to a product with multiple variants
* Verify that the label is read when announcing the select in VoiceOver
* Verify that the label is announced as clickable when using the virtual cursor, and is announced when tabbing to the select in NVDA
* Create a modal buy button for a product with multiple variants
* Navigate a virtual cursor to the modal
* Verify that the label is read when announcing the select in VoiceOver
* Verify that the label is announced as clickable when using the virtual cursor, and is announced when tabbing to the select in NVDA

- [x] Safari - Mac - VoiceOver
- [x] Firefox - Windows - NVDA