### PR TITLE
Use list markup for cart line items

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -117,7 +117,7 @@ export default class Cart extends Component {
       data.text = this.config.lineItem.text;
       data.lineItemImage = this.imageForLineItem(data);
       data.variantTitle = data.variant.title === 'Default Title' ? '' : data.variant.title;
-      return acc + this.childTemplate.render({data}, (output) => `<div id="${lineItem.id}" class=${this.classes.lineItem.lineItem}>${output}</div>`);
+      return acc + this.childTemplate.render({data}, (output) => `<li id="${lineItem.id}" class=${this.classes.lineItem.lineItem}>${output}</li>`);
     }, '');
   }
 

--- a/src/templates/cart.js
+++ b/src/templates/cart.js
@@ -8,7 +8,7 @@ const cartTemplates = {
           </div>`,
   lineItems: `<div class="{{data.classes.cart.cartScroll}}{{#data.contents.note}} {{data.classes.cart.cartScrollWithCartNote}}{{/data.contents.note}}{{#data.discounts}} {{data.classes.cart.cartScrollWithDiscounts}}{{/data.discounts}}" data-element="cart.cartScroll">
                 {{#data.isEmpty}}<p class="{{data.classes.cart.empty}} {{data.classes.cart.emptyCart}}" data-element="cart.empty">{{data.text.empty}}</p>{{/data.isEmpty}}
-                <div class="{{data.classes.cart.lineItems}}" data-element="cart.lineItems">{{{data.lineItemsHtml}}}</div>
+                <ul role="list" class="{{data.classes.cart.lineItems}}" data-element="cart.lineItems">{{{data.lineItemsHtml}}}</ul>
               </div>`,
   footer: `{{^data.isEmpty}}
             <div class="{{data.classes.cart.footer}}" data-element="cart.footer">

--- a/test/unit/cart/cart.js
+++ b/test/unit/cart/cart.js
@@ -139,7 +139,7 @@ describe('Cart class', () => {
       formatMoneySpy.restore();
     });
 
-    it('calls render and returns an html string', () => {
+    it('calls render and returns an html <li /> string', () => {
       cart.lineItemCache = [{
         id: 123,
         title: 'test',
@@ -158,7 +158,9 @@ describe('Cart class', () => {
       }];
 
       const renderSpy = sinon.spy(cart.childTemplate, 'render');
-      assert.include(cart.lineItemsHtml, 'data-line-item-id="123"');
+      const cartLineItemsHtml = cart.lineItemsHtml;
+      assert.include(cartLineItemsHtml, 'data-line-item-id="123"');
+      assert.match(cartLineItemsHtml, /<li\b.*>[\s\S]*<\/li>/);
       assert.calledOnce(renderSpy);
     });
 


### PR DESCRIPTION
* Wrap cart line item list in a `<ul />` 
* Wrap each line item in a `<li />`
* Add a list role to the `<ul/ >` to address a [Safari VoiceOver bug](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#Accessibility_concerns)
  * I didn't opt for the solution posted in MDN since it's more of a hack rather than a permanent solution. This was adding whitespace above the line item product title

**To 🎩** 
* Navigate a virtual cursor to a cart with line items
* Verify that the screen reader announces the line items as a list 

Browsers:
- [x] Safari - Mac - VoiceOver
- [x] Firefox - Windows - NVDA


* Sanity check that cart doesn't look visually different

Browsers: 
- [x] Chrome - Mac
- [x] Safari - Mac
- [x] Firefox - Mac
- [x] Edge - Mac 
- [x] Legacy Edge - Windows
- [x] Edge - Windows
- [x] Chrome - Windows 
- [x] Firefox - Windows
- [x] Safari - iOS
- [x] Chrome - Android
