### PR TITLE
Add visually hidden product details when product is button

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -84,6 +84,9 @@ const defaults = {
       unitPriceAccessibilitySeparator: 'per',
       regularPriceAccessibilityLabel: 'Regular price',
       salePriceAccessibilityLabel: 'Sale price',
+      isButtonModalAccessibilityLabel: 'View details',
+      isButtonCartAccessibilityLabel: 'Add to cart',
+      isButtonCheckoutAccessibilityLabel: 'Buy now',
     },
   },
   modalProduct: {

--- a/src/views/product.js
+++ b/src/views/product.js
@@ -1,4 +1,5 @@
 import View from '../view';
+import Template from '../template';
 
 export default class ProductView extends View {
   get className() {
@@ -46,20 +47,22 @@ export default class ProductView extends View {
   }
 
   wrapTemplate(html) {
-    let ariaLabel;
-    switch (this.component.options.buttonDestination) {
-    case 'modal':
-      ariaLabel = 'View details';
-      break;
-    case 'cart':
-      ariaLabel = 'Add to cart';
-      break;
-    default:
-      ariaLabel = 'Buy Now';
-    }
-
     if (this.component.isButton) {
-      return `<div class="${this.wrapperClass} ${this.component.classes.product.product}"><div tabindex="0" role="button" aria-label="${ariaLabel}" class="${this.component.classes.product.blockButton}">${html}</div></div>`;
+      let ariaLabel;
+      switch (this.component.options.buttonDestination) {
+      case 'modal':
+        ariaLabel = this.component.options.text.isButtonModalAccessibilityLabel;
+        break;
+      case 'cart':
+        ariaLabel = this.component.options.text.isButtonCartAccessibilityLabel;
+        break;
+      default:
+        ariaLabel = this.component.options.text.isButtonCheckoutAccessibilityLabel;
+      }
+
+      const template = new Template(this.component.options.templates, {title: true, price: true}, this.component.options.order);
+      const summaryHtml = template.render({data: this.component.viewData});
+      return `<div class="${this.wrapperClass} ${this.component.classes.product.product}"><div class="visuallyhidden">${summaryHtml}</div><div tabindex="0" role="button" aria-label="${ariaLabel}" class="${this.component.classes.product.blockButton}">${html}</div></div>`;
     } else {
       return `<div class="${this.wrapperClass} ${this.component.classes.product.product}">${html}</div>`;
     }


### PR DESCRIPTION
* Refactor the product isButton aria-label text into options so it can be customized
* Update wrapper to include visually hidden product details summary text when isButton is true
  * This is meant to convey the visual elements of the button that are not accessible for screen readers due to the aria-label on the entire container 
* Although the contents of the button can be customized, including the product title and price covers the basic details of the channel-generated buy buttons with isButton set to true

To 🎩 : 
* Create a buy button where `isButton` is set to true
* Verify that the visually hidden text is not visible when the product is rendered in an iframe
* Navigate a virtual cursor to the buy button and verify that the product title and price is announced
* Verify that a `buttonDestination` of `modal`, `cart`, and `checkout` all have the appropriate aria-label on the button
* Verify the visually hidden text is not present in the DOM when `isButton` is set to false

Browsers: 
- [ ] Safari - Mac - VoiceOver
- [ ] Firefox - Windows