### PR TITLE
Add aria attributes to cart container

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -40,6 +40,7 @@ export default class Cart extends Component {
     this.toggles = toggles.map((toggle) => {
       return new CartToggle(merge({}, config, toggle), Object.assign({}, this.props, {cart: this}));
     });
+    this.index = null;
     this.updater = new CartUpdater(this);
     this.view = new CartView(this);
   }
@@ -137,6 +138,7 @@ export default class Cart extends Component {
       contents: this.options.contents,
       cartNote: this.cartNote,
       cartNoteId: this.cartNoteId,
+      cartTitleId: this.cartTitleId,
     });
   }
 
@@ -191,7 +193,11 @@ export default class Cart extends Component {
   }
 
   get cartNoteId() {
-    return `CartNote-${Date.now()}`;
+    return `CartNote-${this.index}`;
+  }
+
+  get cartTitleId() {
+    return `CartTitle-${this.index}`;
   }
 
   get wrapperClass() {
@@ -494,5 +500,9 @@ export default class Cart extends Component {
     setTimeout(() => {
       this.view.setFocus();
     }, 0);
+  }
+
+  setIndex(index) {
+    this.index = index;
   }
 }

--- a/src/templates/cart.js
+++ b/src/templates/cart.js
@@ -1,6 +1,6 @@
 const cartTemplates = {
   title: `<div class="{{data.classes.cart.header}}" data-element="cart.header">
-            <h2 class="{{data.classes.cart.title}}" data-element="cart.title">{{data.text.title}}</h2>
+            <h2 id="{{data.cartTitleId}}" class="{{data.classes.cart.title}}" data-element="cart.title">{{data.text.title}}</h2>
             <button class="{{data.classes.cart.close}}" data-element="cart.close">
               <span aria-hidden="true">&times;</span>
               <span class="visuallyhidden">{{data.text.closeAccessibilityLabel}}</span>

--- a/src/ui.js
+++ b/src/ui.js
@@ -66,6 +66,9 @@ export default class UI {
       this._bindEsc(component.iframe.el.contentWindow || component.iframe.el);
     }
     this.components[type].push(component);
+    if (type === 'cart') {
+      component.setIndex(this.components[type].indexOf(component));
+    }
     return component.init().then(() => {
       this.trackComponent(type, component);
       return component;
@@ -120,6 +123,7 @@ export default class UI {
     } else {
       const cart = new Cart(config, this.componentProps);
       this.components.cart.push(cart);
+      cart.setIndex(this.components.cart.indexOf(cart));
       return cart.init();
     }
   }

--- a/src/views/cart.js
+++ b/src/views/cart.js
@@ -44,7 +44,7 @@ export default class CartView extends View {
   }
 
   wrapTemplate(html) {
-    return `<div class="${this.component.classes.cart.cart}">${html}</div>`;
+    return `<div class="${this.component.classes.cart.cart}" role="dialog" aria-modal="true" aria-labelledby="${this.component.cartTitleId}">${html}</div>`;
   }
 
   get wrapperClass() {

--- a/test/unit/cart/cart-view.js
+++ b/test/unit/cart/cart-view.js
@@ -259,7 +259,7 @@ describe('Cart View class', () => {
       const mockClass = 'mockClass';
       cart.classes.cart.cart = mockClass;
       cart.view.wrapTemplate(html);
-      assert.equal(cart.view.wrapTemplate(html), `<div class="${mockClass}">${html}</div>`);
+      assert.equal(cart.view.wrapTemplate(html), `<div class="${mockClass}" role="dialog" aria-modal="true" aria-labelledby="${cart.cartTitleId}">${html}</div>`);
     });
   });
 

--- a/test/unit/cart/cart.js
+++ b/test/unit/cart/cart.js
@@ -21,13 +21,10 @@ describe('Cart class', () => {
   let closeCartSpy;
   let trackSpy;
   let viewData;
-  const mockTime = 123;
-  let dateNowStub;
 
   beforeEach(() => {
     closeCartSpy = sinon.spy();
     trackSpy = sinon.spy();
-    dateNowStub = sinon.stub(Date, 'now').returns(mockTime);
 
     cart = new Cart({
       options: {
@@ -72,17 +69,17 @@ describe('Cart class', () => {
   });
 
   afterEach(() => {
-    dateNowStub.restore();
     cart.destroy();
   });
 
   describe('constructor', () => {
-    it('instantiates child template, checkout, toggles, updater, view', () => {
+    it('instantiates child template, checkout, toggles, updater, view, and index', () => {
       assert.instanceOf(cart.childTemplate, Template);
       assert.instanceOf(cart.checkout, Checkout);
       assert.instanceOf(cart.updater, CartUpdater);
       assert.instanceOf(cart.view, CartView);
       assert.instanceOf(cart.toggles[0], CartToggle);
+      assert.equal(cart.index, null);
     });
   });
 
@@ -1103,6 +1100,10 @@ describe('Cart class', () => {
       it('returns an object with cartNoteId', () => {
         assert.equal(viewData.cartNoteId, cart.cartNoteId);
       });
+
+      it('returns an object with cartTitleId', () => {
+        assert.equal(viewData.cartTitleId, cart.cartTitleId);
+      });
     });
 
     describe('without model', () => {
@@ -1141,6 +1142,10 @@ describe('Cart class', () => {
 
       it('returns an object with cartNoteId', () => {
         assert.equal(viewData.cartNoteId, cart.cartNoteId);
+      });
+
+      it('returns an object with cartTitleId', () => {
+        assert.equal(viewData.cartTitleId, cart.cartTitleId);
       });
     });
   });
@@ -1192,8 +1197,18 @@ describe('Cart class', () => {
   });
 
   describe('get cartNoteId', () => {
-    it('returns a string containing the current time in ms', () => {
-      assert.equal(cart.cartNoteId, `CartNote-${mockTime}`);
+    it('returns a string containing the cart`s index', () => {
+      const index = 3;
+      cart.index = index;
+      assert.equal(cart.cartNoteId, `CartNote-${index}`);
+    });
+  });
+
+  describe('get cartTitleId', () => {
+    it('returns a string containing the cart`s index', () => {
+      const index = 3;
+      cart.index = index;
+      assert.equal(cart.cartTitleId, `CartTitle-${index}`);
     });
   });
 
@@ -1610,13 +1625,22 @@ describe('Cart class', () => {
     });
   });
 
+  describe('setIndex', () => {
+    it('sets the index to the value provided', async () => {
+      const index = 5;
+      cart.setIndex(index);
+
+      assert.equal(cart.index, index);
+    });
+  });
+
   describe('setFocus', () => {
     it('calls setFocus on the view after a timeout of 0', () => {
       const setTimeoutStub = sinon.stub(window, 'setTimeout');
       const viewSetFocusStub = sinon.stub(cart.view, 'setFocus');
 
       cart.setFocus();
-      
+
       assert.calledOnce(setTimeoutStub);
       assert.calledWith(setTimeoutStub, sinon.match.func, 0);
 

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -153,11 +153,13 @@ describe('ui class', () => {
           let initStub;
           let trackStub;
           let queryEntryNodeStub;
+          let testNode;
 
           beforeEach(() => {
+            testNode = document.createElement('div');
             initStub = sinon.stub(Product.prototype, 'init').resolves();
             trackStub = sinon.stub(ui, 'trackComponent');
-            queryEntryNodeStub = sinon.stub(ui, '_queryEntryNode').returns('testNode');
+            queryEntryNodeStub = sinon.stub(ui, '_queryEntryNode').returns(testNode);
           });
 
           afterEach(() => {
@@ -182,12 +184,32 @@ describe('ui class', () => {
 
             await ui.createComponent('product', productConfig);
             assert.calledOnce(queryEntryNodeStub);
-            assert.equal(productConfig.node, 'testNode');
+            assert.equal(productConfig.node, testNode);
           });
 
           it('returns the component', async () => {
             const response = await ui.createComponent('product', productConfig);
             assert.instanceOf(response, Product);
+          });
+
+          it('calls setIndex on the component if the component type is cart', async () => {
+            queryEntryNodeStub.restore();
+            const setIndexStub = sinon.stub(Cart.prototype, 'setIndex');
+            await ui.createComponent('cart', {
+              options: {},
+            });
+
+            assert.calledOnce(setIndexStub);
+            assert.calledWith(setIndexStub, 0);
+            setIndexStub.restore();
+          });
+
+          it('does not call setIndex on the component if the component type is not cart', async () => {
+            const setIndexStub = sinon.stub(Cart.prototype, 'setIndex');
+            await ui.createComponent('product', productConfig);
+
+            assert.notCalled(setIndexStub);
+            setIndexStub.restore();
           });
         });
 
@@ -310,6 +332,15 @@ describe('ui class', () => {
             assert.equal(1, ui.components.cart.length);
             assert.instanceOf(ui.components.cart[0], Cart);
             assert.calledOnce(initStub);
+          });
+
+          it('calls setIndex on the cart', async () => {
+            const setIndexStub = sinon.stub(Cart.prototype, 'setIndex');
+            await ui.createCart({options: {}});
+
+            assert.calledOnce(setIndexStub);
+            assert.calledWith(setIndexStub, 0);
+            setIndexStub.restore();
           });
 
           it('returns the init value', async () => {


### PR DESCRIPTION
* Add a `role=dialog` and `aria-modal="true"` to the cart container to signify that it's a modal 
* Add `aria-labelledby` to the container, and connect it to the cart header
  * This involved creating a new method of assigning unique cart ids since the time-based approach resulted in the dom updating every time `render` was called on the cart 
  * The new method adds an index property to the cart class and assigns a value based on the order of cart creation (i.e. if there are 3 carts, the indexes of the components will be `0,1,2`)
  * The new index property was also used for the cart note id, instead of the time-based id


To 🎩 : 
* Navigate a virtual cursor to the cart toggle 
* Open the cart by pressing enter on the dialog
* Verify that the cart is announced as a dialog labelled by the cart title 
  * The screen reader should announce the cart title (Cart), followed by `dialog` or `web dialog`

Browsers: 
- [ ] Safari - Mac - VoiceOver
- [ ] Firefox - Windows - NVDA
