### PR TITLE
Add aria-haspopup attribute to cart toggle

### DIFF
--- a/src/views/toggle.js
+++ b/src/views/toggle.js
@@ -45,6 +45,7 @@ export default class ToggleView extends View {
       this.iframe.parent.setAttribute('tabindex', 0);
       this.iframe.parent.setAttribute('role', 'button');
       this.iframe.parent.setAttribute('aria-label', this.component.options.text.title);
+      this.iframe.parent.setAttribute('aria-haspopup', 'dialog');
       this.resize();
     }
   }

--- a/test/unit/toggle/toggle-view.js
+++ b/test/unit/toggle/toggle-view.js
@@ -86,8 +86,8 @@ describe('Toggle View class', () => {
         toggle.view.render();
       });
 
-      it('updates three attributes', () => {
-        assert.calledThrice(setAttributeSpy);
+      it('updates four attributes', () => {
+        assert.callCount(setAttributeSpy, 4);
       });
 
       it('sets tabindex of iframe\'s parent to zero', () => {
@@ -100,6 +100,10 @@ describe('Toggle View class', () => {
 
       it('sets aria-label of iframe\'s parent to text title', () => {
         assert.calledWith(setAttributeSpy.getCall(2), 'aria-label', toggle.options.text.title);
+      });
+
+      it('sets aria-haspopup of iframe\'s parent to dialog', () => {
+        assert.calledWith(setAttributeSpy.getCall(3), 'aria-haspopup', 'dialog');
       });
 
       it('resizes view', () => {


### PR DESCRIPTION
* Add `aria-haspopup="dialog"` to cart toggle to indicate that it opens a modal context 
* 

To 🎩 : 
* Navigate a virtual cursor to a cart toggle in an iframe
* Verify that it announces the aria attribute 
  * VoiceOver should announce `dialog popup`
  * NVDA should announce `subMenu` - this aria attribute is relatively new and has limited support, but this description should hopefully become clearer as support is added to NVDA

Browsers: 
- [ ] Safari - Mac - VoiceOver
- [ ] Firefox - Windows - NVDA