### PR TITLE
Add aria attributes to modal container

### DIFF
--- a/src/views/modal.js
+++ b/src/views/modal.js
@@ -4,7 +4,7 @@ import {removeTrapFocus} from '../utils/focus';
 
 export default class ModalView extends View {
   wrapTemplate(html) {
-    return `<div class="${this.component.classes.modal.overlay}"><div class="${this.component.classes.modal.modal}">${html}</div></div>`;
+    return `<div class="${this.component.classes.modal.overlay}" role="dialog" aria-modal="true" aria-labelledby="ModalProductTitle"><div class="${this.component.classes.modal.modal}"><div id="ModalProductTitle" hidden>${this.component.model.title}</div>${html}</div></div>`;
   }
 
   /**

--- a/test/unit/modal/modal-view.js
+++ b/test/unit/modal/modal-view.js
@@ -18,6 +18,8 @@ describe('Modal View class', () => {
 
   describe('wrapTemplate', () => {
     it('wraps html in a div element with modal class, and wraps modal div within a div with overlay class', () => {
+      const title = 'Model Title';
+      modal.model.title = title;
       modal = Object.defineProperty(modal, 'classes', {
         value: {
           modal: {
@@ -28,7 +30,7 @@ describe('Modal View class', () => {
       });
       const html = 'html';
       const htmlString =
-        '<div class="overlay"><div class="modal">html</div></div>';
+        `<div class="overlay" role="dialog" aria-modal="true" aria-labelledby="ModalProductTitle"><div class="modal"><div id="ModalProductTitle" hidden>${title}</div>${html}</div></div>`;
       assert.equal(modal.view.wrapTemplate(html), htmlString);
     });
   });


### PR DESCRIPTION
* Add `role="dialog"` and `aria-modal="true"` to convey that the container is a modal
* Add a hidden product title to the modal and reference its id in the `aria-labelledby` attribute of the container 
  * The element is hidden so it is announced when the modal is open, but is not available in the accessibility tree once the modal is open. The same information is contained in the modal, so it would be redundant to have it announced in two different areas. 
* Note: Ideally an id would have been added to the product title in the modal. However, there is a case where the modalProduct component is in an iframe, making it impossible for the parent container to reference that id. 

To 🎩 : 
* Create a buy button with a button destination of modal, and `modalProduct > iframe: false` (default)
* Navigate a virtual cursor to the button
* Click the button by pressing the enter key
* Verify that the product title is announced, followed by `web dialog` (VoiceOver) or `dialog` (NVDA)
* Try to navigate the virtual cursor backwards from the close button, and verify that the new hidden element is not announced
* Repeat the steps above using a buy button with a button destination of modal, and `modalProduct > iframe: true` 

Browsers: 
- [ ] Safari - Mac - VoiceOver
- [ ] Firefox - Windows - NVDA