### PR TITLE
Fix focus outline cutoff in product tile

### DIFF
--- a/src/styles/embeds/sass/components/product.css
+++ b/src/styles/embeds/sass/components/product.css
@@ -3,6 +3,7 @@
 .shopify-buy__product {
   overflow: hidden;
   width: 100%;
+  padding: 5px;
 }
 
 .shopify-buy__product__variant-img {


### PR DESCRIPTION
* Previously, the focus would be cut off for any elements that were near the edge of the iframe. This includes select elements, buttons, and isButton products
* To address this, padding was added to the product container in the iframe giving its contents some space from the iframe boundary

To 🎩 : 
* Create a product buy button with `product > isButton: true`
* Verify that the focus outline is shown around the entire product tile 
* Create a product buy button for a product with options
* Verify that the focus outline is shown around the entire variant select element and the button

Browsers: 
- [ ] Safari - Mac
- [ ] Firefox - Mac 
- [ ] Chrome - Mac 
- [ ] Edge - Mac 
- [ ] Legacy Edge - Windows
- [ ] Edge - Windows
- [ ] Chrome - Windows 
- [ ] Firefox - Windows