### PR TITLE
Update modal close button accessibility label

### DIFF
--- a/src/defaults/components.js
+++ b/src/defaults/components.js
@@ -147,6 +147,9 @@ const defaults = {
     },
     order: ['contents'],
     templates: modalTemplates,
+    text: {
+      closeAccessibilityLabel: 'Close',
+    },
   },
   productSet: {
     iframe: true,

--- a/src/templates/modal.js
+++ b/src/templates/modal.js
@@ -1,8 +1,8 @@
 const modalTemplates = {
   contents: `
               <button class="{{data.classes.modal.close}}" data-element="modal.close">
-                <span aria-role="hidden">&times;</span>
-                <span class="visuallyhidden">Close</span>
+                <span aria-hidden="true">&times;</span>
+                <span class="visuallyhidden">{{data.text.closeAccessibilityLabel}}</span>
               </button>
             `,
 };


### PR DESCRIPTION
* Change `aria-role="hidden"` to `aria-hidden="true"` to ensure the `X` is not announced by the screen reader
* Add text object to default modal config that contains the `closeAccessibilityLabel` 

To 🎩 : 
* Create a buy button where the button destination is `modal` 
* Navigate a virtual cursor to the product button, and click it to open the modal
* Verify that the modal close button does not announce the `X`
* Verify that the modal close button announces accessibility label `Close` 

- [ ] Chrome (Sanity check)
- [ ] Safari/Mac VoiceOver
- [ ] Firefox/Windows NVDA