### PR TITLE
Change product title from h1 to h2

### DIFF
--- a/src/templates/product.js
+++ b/src/templates/product.js
@@ -31,7 +31,7 @@ const productTemplate = {
                         {{/data.carouselImages}}
                       </div>
                     </div>`,
-  title: '<h1 class="{{data.classes.product.title}}" data-element="product.title">{{data.title}}</h1>',
+  title: '<h2 class="{{data.classes.product.title}}" data-element="product.title">{{data.title}}</h2>',
   variantTitle: '{{#data.hasVariants}}<h2 class="{{data.classes.product.variantTitle}}" data-element="product.variantTitle">{{data.selectedVariant.title}}</h2>{{/data.hasVariants}}',
   options: '{{#data.hasVariants}}<div class="{{data.classes.product.options}}" data-element="product.options">{{{data.optionsHtml}}}</div>{{/data.hasVariants}}',
   price: `<div class="{{data.classes.product.prices}}" data-element="product.prices">


### PR DESCRIPTION
* Change product title element from `h1` to `h2`
* Although we're not aware of the context in which buy buttons are embedded, semantically the product title should most likely not be an `h1`  
* In the case of collections, we end up having a bunch of `h1` elements which can make it difficult to parse the page when using a screen reader
* This change also applies to the modal product 

To 🎩 : 
* Create a buy button with a button destination of `modal`
* Navigate a virtual cursor to the product title 
* Verify that it is announced as a `heading level 2`
* Open the product details modal
* Navigate a virtual cursor to the modal product title
* Verify that it is announced as a `heading level 2`
* Sanity check that styling is unaffected by the tag change

- [ ] Chrome, Firefox, Safari (Sanity check)
- [ ] Safari/Mac VoiceOver
- [ ] Firefox/Windows NVDA