### PR TITLE
Add select focus state in legacy edge

### DIFF
--- a/src/styles/embeds/sass/components/select.css
+++ b/src/styles/embeds/sass/components/select.css
@@ -1,6 +1,4 @@
 .shopify-buy__option-select-wrapper {
-  border: 1px solid var(--color-border);
-  border-radius: 3px;
   box-sizing: border-box;
   position: relative;
   background: var(--color-white);
@@ -44,7 +42,8 @@
   font-size: inherit;
   padding: 7px 10px;
   padding-right: 32px;
-  border: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
   width: 100%;
   background: transparent;
   -webkit-appearance: none;
@@ -52,6 +51,10 @@
 
   &::-ms-expand {
     display: none;
+  }
+
+  &:focus {
+    border-color: var(--color-border-focus);
   }
 }
 

--- a/src/styles/embeds/sass/components/select.css
+++ b/src/styles/embeds/sass/components/select.css
@@ -55,6 +55,10 @@
 
   &:focus {
     border-color: var(--color-border-focus);
+
+    @media (-ms-high-contrast: active) {
+      outline: 1px solid var(--color-white);
+    }
   }
 }
 

--- a/src/styles/embeds/sass/variables.css
+++ b/src/styles/embeds/sass/variables.css
@@ -7,6 +7,7 @@
   --color-title: #4c4c4c;
   --color-cart-title: #767676;
   --color-border: #d3dbe2;
+  --color-border-focus: #b3b3b3;
   --color-quantity-border: #767676;
   --color-border-primary: #79ab61;
   --gutter: 15px;


### PR DESCRIPTION
#### Problem
* Legacy Edge does not inherit and user agent focus styles when a select element's appearance has been changed to none. This results in the select elements not having a visible focus state in that browser. 
* It is also missing a focus state in high contrast mode 

#### Solution
* Move borders from the parent div to the select element, so they can be updated when the select element is focused
* Browsers should still inherit their user agent focus styles and have those applied on top of the darkened border
* The `:focus-within` selector could be used to update the parent's border colour when the child `select` is focused, but it is not supported in IE11 or legacy Edge
* Add an outline to the `select` element when it is focused in high contrast mode 

#### To 🎩 : 
* Verify that the default and focus styles of the select elements look the same as before this change
* In legacy edge, verify that the focus state is visible by a darkening of the border
* In high contrast mode, verify that the focus state is visible with a thicker outline

#### Windows:
- [ ] Legacy Edge 18
- [ ] Legacy Edge 17 
- [ ] Chromium Edge 86
- [ ] Chromium Edge 85
- [ ] Firefox 82
- [ ] Firefox 81
- [ ] Chrome 86
- [ ] Chrome 85
- [ ] Opera 72 
- [ ] Opera 71
- [ ] IE11
- [ ] High contrast mode - Legacy Edge 18

#### Mac:
- [ ] Safari 13
- [ ] Safari 12
- [ ] Safari 8
- [ ] Firefox 82
- [ ] Firefox 81
- [ ] Chrome 86
- [ ] Chrome 85
- [ ] Chromium Edge 86
- [ ] Chromium Edge 85
- [ ] Opera 72
- [ ] Opera 71

#### iOS:
- [ ] Safari
- [ ] Chrome

#### Android:
- [ ] Chrome
- [ ] Firefox 
- [ ] Samsung Internet