### PR TITLE
Add label and role to line item images

### DIFF
--- a/src/components/cart.js
+++ b/src/components/cart.js
@@ -116,6 +116,7 @@ export default class Cart extends Component {
       data.classes = this.classes;
       data.text = this.config.lineItem.text;
       data.lineItemImage = this.imageForLineItem(data);
+      data.lineItemImageAltText = this.imageAltTextForLineItem(data);
       data.variantTitle = data.variant.title === 'Default Title' ? '' : data.variant.title;
       return acc + this.childTemplate.render({data}, (output) => `<li id="${lineItem.id}" class=${this.classes.lineItem.lineItem}>${output}</li>`);
     }, '');
@@ -212,6 +213,14 @@ export default class Cart extends Component {
       return this.props.client.image.helpers.imageForSize(lineItem.variant.image, imageOptions);
     } else {
       return NO_IMG_URL;
+    }
+  }
+
+  imageAltTextForLineItem(lineItem) {
+    if (lineItem.variant.image) {
+      return lineItem.variant.image.altText || lineItem.title;
+    } else {
+      return null;
     }
   }
 

--- a/src/templates/line-item.js
+++ b/src/templates/line-item.js
@@ -1,5 +1,5 @@
 const lineItemTemplates = {
-  image: '<div class="{{data.classes.lineItem.image}}" style="background-image: url({{data.lineItemImage}})" data-element="lineItem.image"></div>',
+  image: '<div class="{{data.classes.lineItem.image}}" style="background-image: url({{data.lineItemImage}})" data-element="lineItem.image" {{#data.lineItemImageAltText}} role="img" aria-label="{{data.lineItemImageAltText}}" {{/data.lineItemImageAltText}}></div>',
   variantTitle: '<div class="{{data.classes.lineItem.variantTitle}}" data-element="lineItem.variantTitle">{{data.variantTitle}}</div>',
 
   title: '<span class="{{data.classes.lineItem.itemTitle}}" data-element="lineItem.itemTitle">{{data.title}}</span>',


### PR DESCRIPTION
* Add role of `img` to the line item image div, and add an `aria-label`
  * These will be conditionally added, if the image has alt text. Otherwise, we'll be showing the default shopping bag image that doesn't need to be announced to screen readers. 
* Add helper function to the cart to get value for the aria-label
  * It will return the line item variant image alt text if it exists, otherwise will return the line item title (product title). If the line item doesn't have an image, it will return null.


To 🎩 : 
* Add a variant to the cart that has an image with alt text 
  * Verify that the line item image div has a role of image
  * Verify that the image alt text is the aria-label on line item image div
  * Verify that screenreaders announce the image and the label
* Add a variant to the cart that does not have alt text
  * Verify that the line item image div has a role of image
  * Verify that the line item / product title is the aria-label on the line item image div 
  * Verify that screenreaders announce the image and the label
* Add a variant to the cart whose product does not have any images
  * Verify that the default shopping bag image appears for the line item
  * Verify that the line item image div does not have a role or aria-label
  * Verify that screenreaders do not announce the image

- [ ] Chrome
- [ ] Safari/Mac - VoiceOver
- [ ] Firefox/Windows - NVDA