### PR TITLE
Bump JS Buy SDK to v2.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "morphdom": "2.5.5",
     "mustache": "3.0.1",
     "node-sass": "4.12.0",
-    "shopify-buy": "2.11.0",
+    "shopify-buy": "2.12.0",
     "uglify-js": "3.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6322,10 +6322,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.11.0.tgz#0f7cb52741395e4ae778c336f32ddf3fe67c2f35"
-  integrity sha512-bGjS1b/VCPvCjazSstlKwgLtK1WBotWom06/12loja8yfo/cWkLuJsakBbQe1uEIDiOLhKaR0M0CAXZFheYDug==
+shopify-buy@2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.12.0.tgz#d10609e291d41d537bb29cff73c604d14c117692"
+  integrity sha512-L0fo8fBDO31v9dAlVmLlIuJQnfwexGvceJ+A8hhIpovvfGh4GVGDId3k9PCWOqSzVHQBvYLdeGccxqjAOlbRlg==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
Bumps the SDK to use Storefront API version 2021-07. 
see: https://github.com/Shopify/js-buy-sdk/releases/tag/v2.12.0