### PR TITLE
Remove encoding during normalizing the ids

### DIFF
--- a/src/utils/normalize-config.js
+++ b/src/utils/normalize-config.js
@@ -1,5 +1,5 @@
 function normalizeId(type, databaseKey) {
-  return btoa(`gid://shopify/${type}/${databaseKey}`);
+  return `gid://shopify/${type}/${databaseKey}`;
 }
 
 function getNormalizedIdFromConfig(type, config, databaseKey, storefrontKey) {


### PR DESCRIPTION
Remove the `btoa` encoding of `ids` since Storefront API does not return `base64` ids anymore. 

To 🎩 : 
- add a `variantId` value to the Buy Button config where the variant id is not the first/default variant