### PR TITLE
ensure options.modalProduct.styles get passed through to view when options.product.styles is false

### DIFF
--- a/src/components/product.js
+++ b/src/components/product.js
@@ -525,7 +525,7 @@ export default class Product extends Component {
         return productStyles;
       }, {}), this.config.modalProduct.styles);
     } else {
-      modalProductStyles = {};
+      modalProductStyles = this.config.modalProduct.styles;
     }
 
     return Object.assign({}, this.config.modalProduct, {


### PR DESCRIPTION
Fixes a bug where if `options.modalProduct.styles` is configured but `options.product.styles` is not set, the `modalProduct` styles are disregarded. 