### PR TITLE
Update JS Buy SDK to v2.19.0 and fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "morphdom": "2.6.1",
     "mustache": "3.0.1",
     "sass": "1.54.3",
-    "shopify-buy": "2.16.1",
+    "shopify-buy": "2.19.0",
     "uglify-js": "3.16.3"
   },
   "resolutions": {

--- a/test/fixtures/product-fixture.js
+++ b/test/fixtures/product-fixture.js
@@ -42,9 +42,12 @@ const testProduct = {
     {
       id: 'gid://shopify/ProductVariant/19667571022088',
       productId: 123,
-      price: '123.00',
+      price: {
+        amount: '123.0',
+        currencyCode: 'CAD',
+      },
       priceV2: {
-        amount: '123.00',
+        amount: '123.0',
         currencyCode: 'CAD',
       },
       title: 'sloth / small',
@@ -67,9 +70,12 @@ const testProduct = {
     {
       id: 'gid://shopify/ProductVariant/19667555522084',
       productId: 123,
-      price: '1.00',
+      price: {
+        amount: '1.0',
+        currencyCode: 'CAD',
+      },
       priceV2: {
-        amount: '1.00',
+        amount: '1.0',
         currencyCode: 'CAD',
       },
       title: 'shark / small',
@@ -92,7 +98,10 @@ const testProduct = {
     {
       id: 'gid://shopify/ProductVariant/19667555522789',
       productId: 123,
-      price: '999.99',
+      price: {
+        amount: '999.99',
+        currencyCode: 'CAD',
+      },
       priceV2: {
         amount: '999.99',
         currencyCode: 'CAD',
@@ -117,9 +126,12 @@ const testProduct = {
     {
       id: 'gid://shopify/ProductVariant/196675555224567',
       productId: 123,
-      price: '0.00',
+      price: {
+        amount: '0.0',
+        currencyCode: 'CAD',
+      },
       priceV2: {
-        amount: '0.00',
+        amount: '0.0',
         currencyCode: 'CAD',
       },
       title: 'cat / small',

--- a/test/unit/cart/cart.js
+++ b/test/unit/cart/cart.js
@@ -150,7 +150,7 @@ describe('Cart class', () => {
             src: 'cdn.shopify.com/image.jpg',
           },
           priceV2: {
-            amount: '5.00',
+            amount: '5.0',
             currencyCode: 'CAD',
           },
         },
@@ -175,7 +175,7 @@ describe('Cart class', () => {
             src: 'cdn.shopify.com/image.jpg',
           },
           priceV2: {
-            amount: '5.00',
+            amount: '5.0',
             currencyCode: 'CAD',
           },
         },
@@ -623,7 +623,7 @@ describe('Cart class', () => {
           quantity: 1,
           variant: {
             priceV2: {
-              amount: '10.00',
+              amount: '10.0',
               currencyCode: 'CAD',
             },
           },
@@ -1043,7 +1043,7 @@ describe('Cart class', () => {
               id: 1111,
               title: 'test variant',
               priceV2: {
-                amount: '20.00',
+                amount: '20.0',
                 currencyCode: 'CAD',
               },
             },
@@ -1054,9 +1054,12 @@ describe('Cart class', () => {
           id: 1,
           lineItems,
           note: 'test cart note',
-          subtotalPrice: '123.00',
+          subtotalPrice: {
+            amount: '130.0',
+            currencyCode: 'USD',
+          },
           subtotalPriceV2: {
-            amount: '130.00',
+            amount: '130.0',
             currencyCode: 'USD',
           },
           discountApplications: [],
@@ -1616,7 +1619,7 @@ describe('Cart class', () => {
       const viewSetFocusStub = sinon.stub(cart.view, 'setFocus');
 
       cart.setFocus();
-      
+
       assert.calledOnce(setTimeoutStub);
       assert.calledWith(setTimeoutStub, sinon.match.func, 0);
 

--- a/test/unit/product-set.js
+++ b/test/unit/product-set.js
@@ -389,9 +389,12 @@ describe('ProductSet class', () => {
           {
             id: 'GTYOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC8xMjM0NQ==',
             productId: 1245,
-            price: '20.00',
+            price: {
+              amount: '20.0',
+              currencyCode: 'CAD',
+            },
             priceV2: {
-              amount: '20.00',
+              amount: '20.0',
               currencyCode: 'CAD',
             },
             title: 'sloth / small',

--- a/test/unit/product/product-component.js
+++ b/test/unit/product/product-component.js
@@ -1394,7 +1394,7 @@ describe('Product Component class', () => {
           it('returns formatted money with selected variant price and money format from global config if there is a selected variant', () => {
             product.selectedVariant = {
               priceV2: {
-                amount: '5.00',
+                amount: '5.0',
                 currencyCode: 'CAD',
               },
             };
@@ -1415,7 +1415,7 @@ describe('Product Component class', () => {
           it('returns formatted money with selected variant compare at price and money format from global config if there is a selected variant', () => {
             product.selectedVariant = {
               compareAtPriceV2: {
-                amount: '5.00',
+                amount: '5.0',
                 currencyCode: 'CAD',
               },
             };
@@ -2422,7 +2422,7 @@ describe('Product Component class', () => {
             title: 'hat',
             id: 'AAkdlfjljwijk3j35j3ljksLqQkslj',
             priceV2: {
-              amount: '5.00',
+              amount: '5.0',
               currencyCode: 'CAD',
             },
           };
@@ -2448,7 +2448,7 @@ describe('Product Component class', () => {
             id: '456',
             title: 'hat',
             priceV2: {
-              amount: '5.00',
+              amount: '5.0',
               currencyCode: 'CAD',
             },
           };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,10 +5910,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.16.1.tgz#d5062813df68fe39a6579a8da07bd6a4fdce5a13"
-  integrity sha512-I+4pmFgYpQ8N3yaqNw/5fWu+e7AuiUIrQdDLPtD0SwEzL1EyB4q2Ge+MSHQmrAaZFiDXKHAkfzpkYExztquaDw==
+shopify-buy@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.19.0.tgz#5c1e0f9fd0fb91266f467c7a8fca1ec7100d983a"
+  integrity sha512-XCkQDG9DokhWUiRTOh+6K9I2w3uMys+R1mCt8h3l4le/9TjVxVJ1jbWD7ioyPf1Bc+fPLR6KX62JT1K6NE/S8A==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
Update the JS Buy SDK version to `v2.19.0` that calls Storefront API `v2023-04`

![bbjs-jsbuysdk-v2 19 0-1](https://github.com/Shopify/buy-button-js/assets/6719231/8cc0c086-4b6f-4910-8fcd-339c5297fd35)
