### PR TITLE
Update JS Buy SDK to v2.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "morphdom": "2.6.1",
     "mustache": "3.0.1",
     "sass": "1.54.3",
-    "shopify-buy": "2.19.0",
+    "shopify-buy": "2.20.0",
     "uglify-js": "3.16.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,10 +5910,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.19.0.tgz#5c1e0f9fd0fb91266f467c7a8fca1ec7100d983a"
-  integrity sha512-XCkQDG9DokhWUiRTOh+6K9I2w3uMys+R1mCt8h3l4le/9TjVxVJ1jbWD7ioyPf1Bc+fPLR6KX62JT1K6NE/S8A==
+shopify-buy@2.20.0:
+  version "2.20.0"
+  resolved "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.20.0.tgz#b6455e78c01e28b0ddca61fb0c5a15ab66720a2c"
+  integrity sha512-xe6VlqJtI/c8BYeH2hhOw7gZSsbHUeGFUwVyAzQOR422Ml4UXTFld0GcbW88tkR/Vgy2tj592EL2paCws2fZzQ==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
Update the library to use JS Buy SDK `v2.20.0` - this version of the SDK requests from Storefront API `2023-07`.

<img width="1293" alt="Screenshot 2023-07-06 at 12 03 16 PM" src="https://github.com/Shopify/buy-button-js/assets/6719231/5ca77a3a-c934-4210-9697-932c36c152a6">

![bb-js-sfapi-2 20 0](https://github.com/Shopify/buy-button-js/assets/6719231/6d84ad41-721d-4501-b8d9-669939bdf6eb)
