### PR TITLE
Bump shopify-buy to 3.0.5

### DIFF
--- a/.changeset/thirty-hats-cross.md
+++ b/.changeset/thirty-hats-cross.md
@@ -1,0 +1,5 @@
+---
+"@shopify/buy-button-js": patch
+---
+
+Bump shopify-buy dependency version to 3.0.5

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "morphdom": "2.6.1",
     "mustache": "3.0.1",
     "sass": "1.69.0",
-    "shopify-buy": "2.20.0",
+    "shopify-buy": "3.0.5",
     "uglify-js": "3.16.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6442,10 +6442,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shopify-buy@2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-2.20.0.tgz#b6455e78c01e28b0ddca61fb0c5a15ab66720a2c"
-  integrity sha512-xe6VlqJtI/c8BYeH2hhOw7gZSsbHUeGFUwVyAzQOR422Ml4UXTFld0GcbW88tkR/Vgy2tj592EL2paCws2fZzQ==
+shopify-buy@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/shopify-buy/-/shopify-buy-3.0.5.tgz#911a1c90493c0459dd569510e11997596742cdca"
+  integrity sha512-xLz9FhdcCFRTPN5YKrQpiEtn3mcyZy7kvWITnY41ypwklTZAW0yIPC7fzRN0PdXGqFSldqiGO3Nj99lYELM02w==
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
Following the steps in https://github.com/Shopify/buy-button-js/blob/main/DEPLOYING.md