### PR TITLE
Restore changeset for change that didn't get deployed to npm

### DIFF
--- a/.changeset/three-stars-study.md
+++ b/.changeset/three-stars-study.md
@@ -1,0 +1,5 @@
+---
+"@shopify/buy-button-js": patch
+---
+
+Bump shopify-buy to from 3.0.5 to 3.0.6

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -22,7 +22,7 @@ npx changeset add
 
 ### 4. Push your changes
 ```
-git push origin main
+git push
 ```
 
 ### 5. Create a PR and merge it into `main`


### PR DESCRIPTION
**Why do we need to do this?**
A few of the "publish to npm" workflows failed earlier today in the "Update package.json version and reset changesets" step because the GitHub Actions bot did not have the required permissions to merge into main without a PR.

Therefore, when my most recent PR merged, the npm deploy workflow failed because it tried to (re-)release version 3.0.3 since my package.json said 3.0.2 and my changeset showed this was a patch change. Ie: the package.json version when my PR merged did not reflect the actual version of the package published in npm.

Since then, I updated the GitHub branch permissions and re-ran the workflow that failed due to permission issues. This then updated the package.json version to 3.0.3 (reflecting what's in npm) and deleted the changeset I added, but ultimately did not release a new version (based on my changes) to npm (ie: version 3.0.4).

By adding the changeset back (for the version bump that didn't get released to npm in my previous PR), merging this PR should hopefully release v3.0.4