### PR TITLE
fix: run CI on all pull requests, not just those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
The pull_request trigger had `branches: [main]`, which meant CI only
ran on PRs whose base branch is main. Stacked PRs (which target
intermediate branches) never got CI coverage. Remove the branch
filter so CI runs on every PR regardless of base branch.

The push trigger retains `branches: [main]` — we only want push
CI on main merges, not on every branch push.