### PR TITLE
chore: enable automatic CHANGELOG generation via Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": false,
+  "changelog": ["@changesets/changelog-github", { "repo": "Shopify/buy-button-js" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Update package version and remove changesets
         if: env.changesets_found == 'true'
         run: pnpm exec changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to NPM
         if: env.changesets_found == 'true'
@@ -69,6 +71,6 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add package.json .changeset
+          git add package.json .changeset CHANGELOG.md
           git commit -m "Update package version & delete changesets"
           git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### v3.0.6 (Unreleased)
+### v3.0.6 (August 25, 2025)
 - Add title attribute to iframes for improved accessibility ([#919](https://github.com/Shopify/buy-button-js/pull/919))
 
 ### v3.0.5 (July 2, 2025)

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@babel/plugin-transform-template-literals": "7.4.4",
     "@babel/plugin-transform-typeof-symbol": "7.2.0",
     "@babel/preset-typescript": "^7.27.1",
+    "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.28.1",
     "@shopify/js-uploader": "https://github.com/Shopify/js-uploader.git",
     "@types/jest": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.5.5)
+      '@changesets/changelog-github':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@changesets/cli':
         specifier: ^2.28.1
         version: 2.28.1
@@ -435,6 +438,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.6.0':
+    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
+
   '@changesets/cli@2.28.1':
     resolution: {integrity: sha512-PiIyGRmSc6JddQJe/W1hRPjiN4VrMvb2VfQ6Uydy2punBioQrsxppyG5WafinKcW1mT0jOe/wU4k9Zy5ff21AA==}
     hasBin: true
@@ -447,6 +453,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.8.0':
+    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.8':
     resolution: {integrity: sha512-MM4mq2+DQU1ZT7nqxnpveDMTkMBLnwNX44cX7NSxlXmr7f8hO6/S2MXNiXG54uf/0nYnefv0cfy4Czf/ZL/EKQ==}
@@ -1504,6 +1513,9 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   date-now@0.1.4:
     resolution: {integrity: sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==}
 
@@ -1656,6 +1668,10 @@ packages:
   domain-browser@1.2.0:
     resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
     engines: {node: '>=0.4', npm: '>=1.2'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
@@ -2864,6 +2880,15 @@ packages:
   node-environment-flags@1.0.5:
     resolution: {integrity: sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-notifier@5.2.1:
     resolution: {integrity: sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==}
 
@@ -3964,6 +3989,9 @@ packages:
     resolution: {integrity: sha512-42UXjmzk88F7URyg9wDV/dlQ7hXtl/SDV6xIMVdDq82cnDGQDyg8mI8xGBPOwpEfbhvrja6cJ8H1wr0xxykBKA==}
     engines: {node: '>=0.8'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tryit@1.0.3:
     resolution: {integrity: sha512-6C5h3CE+0qjGp+YKYTs74xR0k/Nw/ePtl/Lp6CCf44hqBQ66qnH1sDFR5mV/Gc48EsrHLB53lCFSffQCkka3kg==}
 
@@ -4102,11 +4130,17 @@ packages:
     deprecated: outdated version, please use @next
     hasBin: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   wgxpath@1.0.0:
     resolution: {integrity: sha512-2Hp4+h29WkaYf3eudZwYttm7efBuMdvWgCkD7xMveAxDqzIeB2WasyEWHHxxh7iHXehDH5NFEZ2X4q1uaZOxnQ==}
 
   whatwg-fetch@3.0.0:
     resolution: {integrity: sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-module@2.0.0:
     resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==}
@@ -4587,6 +4621,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.6.0':
+    dependencies:
+      '@changesets/get-github-info': 0.8.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.28.1':
     dependencies:
       '@changesets/apply-release-plan': 7.0.10
@@ -4638,6 +4680,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.1
+
+  '@changesets/get-github-info@0.8.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.8':
     dependencies:
@@ -5731,6 +5780,8 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  dataloader@1.4.0: {}
+
   date-now@0.1.4: {}
 
   debug@2.6.8:
@@ -5856,6 +5907,8 @@ snapshots:
       isarray: 1.0.0
 
   domain-browser@1.2.0: {}
+
+  dotenv@8.6.0: {}
 
   duplexer2@0.1.4:
     dependencies:
@@ -7315,6 +7368,10 @@ snapshots:
       object.getownpropertydescriptors: 2.0.3
       semver: 5.7.0
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-notifier@5.2.1:
     dependencies:
       growly: 1.3.0
@@ -8633,6 +8690,8 @@ snapshots:
     dependencies:
       punycode: 1.4.1
 
+  tr46@0.0.3: {}
+
   tryit@1.0.3: {}
 
   tty-browserify@0.0.1: {}
@@ -8772,9 +8831,16 @@ snapshots:
       wdio-dot-reporter: 0.0.6
       wgxpath: 1.0.0
 
+  webidl-conversions@3.0.1: {}
+
   wgxpath@1.0.0: {}
 
   whatwg-fetch@3.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-module@2.0.0: {}
 


### PR DESCRIPTION
Part of https://github.com/Shopify/developer-tools-team/issues/1195

---

Switch from manual CHANGELOG management to @changesets/changelog-github.
- Update .changeset/config.json to use @changesets/changelog-github
- Pass GITHUB_TOKEN to changeset version step in release workflow
  (@changesets/changelog-github needs it to fetch PR metadata for links)
- Fix git add to include CHANGELOG.md (pre-existing bug — changeset version
  modifies CHANGELOG.md but it was never staged in the commit step)
- Fix stale v3.0.6 '(Unreleased)' label — published to npm August 25, 2025

## Verification

Smoke-tested the CHANGELOG automation locally:

1. Created a temporary test changeset (`@shopify/buy-button-js: patch`)
2. Ran `GITHUB_TOKEN=$(gh auth token) pnpm exec changeset version`
3. Confirmed CHANGELOG.md was updated with a new `## 3.0.7` section containing the test entry
4. Reverted all changes (`git checkout -- package.json CHANGELOG.md && rm .changeset/test-changelog-automation.md`)

Result: `changeset version` exits 0, plugin loads correctly, and CHANGELOG.md is generated with proper formatting.