### PR TITLE
chore: add CODEOWNERS for developer-platforms team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Shopify/developer-platforms


### PR DESCRIPTION
Auto-request reviews from @Shopify/developer-platforms on all PRs,
matching the pattern used by Hydrogen and other team repos. Example:
https://github.com/Shopify/hydrogen/blob/main/.github/CODEOWNERS