### PR TITLE
feat: migrate npm-release.yml to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write      # push version commits, create GitHub releases
       pull-requests: write # create/update the "[ci] release" PR
-      id-token: write      # OIDC for npm provenance attestation
+      id-token: write      # OIDC for npm trusted publishing AND provenance attestation
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "18.20"
+          node-version: "24"
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -56,6 +56,8 @@ jobs:
           # scoped to this repo only (contents:write, pull-requests:write),
           # rotated every 2 hours via github-actions-access-provider.
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Empty NPM_TOKEN forces npm to fall through to OIDC token exchange.
+          # Do NOT set NODE_AUTH_TOKEN — setup-node's registry-url writes it
+          # into .npmrc; leaving it undefined triggers the OIDC flow.
+          NPM_TOKEN: ''
           NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   ],
   "description": "BuyButton.js allows merchants to build Shopify interfaces into any website",
   "main": "lib/buybutton.umd.js",
-  "repository": "git@github.com:Shopify/buy-button-js.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/buy-button-js.git"
+  },
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
Part of https://github.com/Shopify/developer-tools-team/issues/1195

---

## Summary

- Migrate npm-release.yml from static `NPM_TOKEN` to OIDC trusted publishing
- Fix `package.json` repository field from SSH shorthand to structured HTTPS format (required for provenance attestation, which is a prerequisite for OIDC trusted publishing)

## Why

OIDC replaces long-lived `NPM_TOKEN` secrets with short-lived tokens derived from the GitHub Actions workflow identity. This eliminates the risk of credential compromise — tokens are scoped to the specific workflow run and cannot be reused. Standard at Shopify (Hydrogen, CLI, theme-tools, flash-list).

npm classic tokens were revoked December 9, 2025. This repo's `NPM_TOKEN` was a classic token, so it's already dead and this migration is a necessity in order to do future npm releases.

## How OIDC works

1. `id-token: write` permission allows the workflow to request an OIDC token from GitHub
2. `setup-node` with `registry-url` configures `.npmrc` for auth
3. `NODE_AUTH_TOKEN` is NOT set — this causes npm to fall through to OIDC token exchange
4. `NPM_TOKEN: ''` (empty string) explicitly forces OIDC fallback
5. npm 11 (bundled with Node 24) natively supports OIDC token exchange with npmjs.com

## Snapit

(similar to Hydrogen) Snapit OIDC migration is **deferred**. Only `npm-release.yml` is configured as a Trusted Publisher on npmjs.com. To get `/snapit` to work we would need to move the contents of the snapit.yml into npm-release.yml.
- We do not need `/snapit` to test our changes and verify everything works. We can instead just manually build this package and use that rather than the npm release from `/snapit`